### PR TITLE
feat: add central cicd templates

### DIFF
--- a/.github/workflows/reusable_ci.yml
+++ b/.github/workflows/reusable_ci.yml
@@ -1,0 +1,65 @@
+name: Reusable CI
+
+on:
+  workflow_call:
+    inputs:
+      python_version:
+        required: false
+        type: string
+        default: "3.12"
+      node_version:
+        required: false
+        type: string
+        default: "20"
+      backend_install_command:
+        required: false
+        type: string
+        default: "uv sync --extra dev"
+      backend_test_command:
+        required: true
+        type: string
+      frontend_working_directory:
+        required: false
+        type: string
+        default: "frontend"
+      frontend_install_command:
+        required: false
+        type: string
+        default: "npm install"
+      frontend_build_command:
+        required: false
+        type: string
+        default: "npm run build"
+
+jobs:
+  reusable-ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python_version }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node_version }}
+
+      - name: Install uv
+        run: python -m pip install uv
+
+      - name: Install backend dependencies
+        run: ${{ inputs.backend_install_command }}
+
+      - name: Run backend checks
+        run: ${{ inputs.backend_test_command }}
+
+      - name: Build frontend
+        if: ${{ inputs.frontend_working_directory != '' }}
+        working-directory: ${{ inputs.frontend_working_directory }}
+        run: |
+          ${{ inputs.frontend_install_command }}
+          ${{ inputs.frontend_build_command }}

--- a/.github/workflows/reusable_deploy.yml
+++ b/.github/workflows/reusable_deploy.yml
@@ -1,0 +1,123 @@
+name: Reusable Deploy
+
+on:
+  workflow_call:
+    inputs:
+      python_version:
+        required: false
+        type: string
+        default: "3.12"
+      node_version:
+        required: false
+        type: string
+        default: "20"
+      backend_install_command:
+        required: false
+        type: string
+        default: "uv sync --extra dev"
+      backend_verify_command:
+        required: true
+        type: string
+      frontend_working_directory:
+        required: false
+        type: string
+        default: "frontend"
+      frontend_install_command:
+        required: false
+        type: string
+        default: "npm install"
+      frontend_build_command:
+        required: false
+        type: string
+        default: "npm run build"
+      remote_deploy_command:
+        required: true
+        type: string
+    secrets:
+      DEPLOY_HOST:
+        required: true
+      DEPLOY_PORT:
+        required: false
+      DEPLOY_USER:
+        required: true
+      DEPLOY_PATH:
+        required: true
+      DEPLOY_SSH_PRIVATE_KEY:
+        required: true
+      DEPLOY_SUDO_PASSWORD:
+        required: false
+
+jobs:
+  reusable-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python_version }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node_version }}
+
+      - name: Install uv
+        run: python -m pip install uv
+
+      - name: Verify backend
+        run: |
+          ${{ inputs.backend_install_command }}
+          ${{ inputs.backend_verify_command }}
+
+      - name: Build frontend
+        if: ${{ inputs.frontend_working_directory != '' }}
+        working-directory: ${{ inputs.frontend_working_directory }}
+        run: |
+          ${{ inputs.frontend_install_command }}
+          ${{ inputs.frontend_build_command }}
+
+      - name: Prepare SSH
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_PORT: ${{ secrets.DEPLOY_PORT }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+        run: |
+          test -n "$DEPLOY_HOST"
+          test -n "$DEPLOY_USER"
+          test -n "$DEPLOY_SSH_PRIVATE_KEY"
+          install -d -m 700 ~/.ssh
+          printf '%s\n' "$DEPLOY_SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -p "${DEPLOY_PORT:-22}" "$DEPLOY_HOST" >> ~/.ssh/known_hosts
+
+      - name: Upload bundle
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_PORT: ${{ secrets.DEPLOY_PORT }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+        run: |
+          ssh -p "${DEPLOY_PORT:-22}" "$DEPLOY_USER@$DEPLOY_HOST" "mkdir -p '$DEPLOY_PATH'"
+          tar \
+            --exclude='.git' \
+            --exclude='.github' \
+            --exclude='node_modules' \
+            --exclude='.venv' \
+            -czf - . \
+          | ssh -p "${DEPLOY_PORT:-22}" "$DEPLOY_USER@$DEPLOY_HOST" "tar -xzf - -C '$DEPLOY_PATH'"
+
+      - name: Run remote deploy
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_PORT: ${{ secrets.DEPLOY_PORT }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+          DEPLOY_SUDO_PASSWORD: ${{ secrets.DEPLOY_SUDO_PASSWORD }}
+          REMOTE_DEPLOY_COMMAND: ${{ inputs.remote_deploy_command }}
+        run: |
+          ssh -p "${DEPLOY_PORT:-22}" "$DEPLOY_USER@$DEPLOY_HOST" \
+            "cd '$DEPLOY_PATH' && DEPLOY_PATH='$DEPLOY_PATH' DEPLOY_SUDO_PASSWORD='$DEPLOY_SUDO_PASSWORD' bash -lc \"$REMOTE_DEPLOY_COMMAND\""

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .env
 __pycache__/
 .DS_Store
+
+outputs/
+.venv/

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ The project now includes a first pass of **real Git/GitHub execution tools** for
 - `reviewer` / `master` can inspect branch diff summaries and the persisted GitHub state
 - `master` can submit native GitHub PR reviews (`COMMENT`, `APPROVE`, `REQUEST_CHANGES`)
 - `master` can merge a real PR when the final decision is `MERGE`
+- merged PR 对应的远端 branch 默认保留，便于用户查看 node 改动；只有明确要求时才删除
 
 Required environment variables:
 
@@ -114,6 +115,26 @@ The project now includes a first pass of **real GitHub Actions CI/CD integration
 - `node` can commit, push, and open PRs for CI/CD changes in its own branch + worktree
 - `reviewer` / `master` can verify whether workflow files and repo secrets were actually configured
 
+## Central CI/CD Templates
+
+`multi_dev` 现在也可以作为统一 CI/CD 模板中心：
+
+- 中心模板仓库提供 reusable workflows：
+  - `.github/workflows/reusable_ci.yml`
+  - `.github/workflows/reusable_deploy.yml`
+- 新项目仓库只需生成两个超薄 workflow 文件：
+  - `.github/workflows/ci.yml`
+  - `.github/workflows/deploy.yml`
+- 这两个超薄文件统一 `uses:` 中心模板，项目侧只保留项目自己的命令参数
+
+建议配套环境变量：
+
+```bash
+CREW_CICD_TEMPLATE_REPO=your-owner/multi_dev
+CREW_CICD_TEMPLATE_REF=main
+```
+
+当 `CREW_CICD_TEMPLATE_REPO` 已明确时，优先生成超薄 workflow，而不是在每个项目里重复写整套 CI/CD。
 
 Recommended deployment environment variables:
 

--- a/src/multi_dev/crew.py
+++ b/src/multi_dev/crew.py
@@ -4,6 +4,7 @@ from crewai import Agent, Crew, LLM, Process, Task
 from crewai.agents.agent_builder.base_agent import BaseAgent
 from crewai.project import CrewBase, agent, crew, task
 from multi_dev.tools import (
+    ScaffoldThinCICDWorkflowsTool,
     GitBranchDiffSummaryTool,
     GitCommitAndPushTool,
     GitHubBootstrapRepoTool,
@@ -110,6 +111,7 @@ class MultiDev:
             *self.read_tools(),
             ReadGitHubStateTool(),
             GitBranchDiffSummaryTool(),
+            ScaffoldThinCICDWorkflowsTool(),
             GitHubBootstrapRepoTool(),
             GitHubCreateIssueTool(),
             GitHubReviewPRTool(),

--- a/src/multi_dev/templates/cicd/ci.thin.yml
+++ b/src/multi_dev/templates/cicd/ci.thin.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  ci:
+    uses: __TEMPLATE_REPO__/.github/workflows/reusable_ci.yml@__TEMPLATE_REF__
+    with:
+      python_version: "__PYTHON_VERSION__"
+      node_version: "__NODE_VERSION__"
+      backend_install_command: "__BACKEND_INSTALL_COMMAND__"
+      backend_test_command: "__BACKEND_TEST_COMMAND__"
+      frontend_working_directory: "__FRONTEND_WORKDIR__"
+      frontend_install_command: "__FRONTEND_INSTALL_COMMAND__"
+      frontend_build_command: "__FRONTEND_BUILD_COMMAND__"

--- a/src/multi_dev/templates/cicd/deploy.thin.yml
+++ b/src/multi_dev/templates/cicd/deploy.thin.yml
@@ -1,0 +1,24 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: app-deploy
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    uses: __TEMPLATE_REPO__/.github/workflows/reusable_deploy.yml@__TEMPLATE_REF__
+    with:
+      python_version: "__PYTHON_VERSION__"
+      node_version: "__NODE_VERSION__"
+      backend_install_command: "__BACKEND_INSTALL_COMMAND__"
+      backend_verify_command: "__BACKEND_VERIFY_COMMAND__"
+      frontend_working_directory: "__FRONTEND_WORKDIR__"
+      frontend_install_command: "__FRONTEND_INSTALL_COMMAND__"
+      frontend_build_command: "__FRONTEND_BUILD_COMMAND__"
+      remote_deploy_command: "__REMOTE_DEPLOY_COMMAND__"
+    secrets: inherit

--- a/src/multi_dev/tools/__init__.py
+++ b/src/multi_dev/tools/__init__.py
@@ -1,3 +1,4 @@
+from multi_dev.tools.cicd_template_tools import ScaffoldThinCICDWorkflowsTool
 from multi_dev.tools.git_github_tools import (
     GitBranchDiffSummaryTool,
     GitCommitAndPushTool,
@@ -20,6 +21,7 @@ from multi_dev.tools.repo_execution_tools import (
 )
 
 __all__ = [
+    "ScaffoldThinCICDWorkflowsTool",
     "GitBranchDiffSummaryTool",
     "GitCommitAndPushTool",
     "GitHubBootstrapRepoTool",

--- a/src/multi_dev/tools/cicd_template_tools.py
+++ b/src/multi_dev/tools/cicd_template_tools.py
@@ -1,0 +1,124 @@
+from pathlib import Path
+from typing import Type
+
+from crewai.tools import BaseTool
+from pydantic import BaseModel, Field
+
+from multi_dev.tools.git_github_tools import target_repository_root
+
+
+def template_root() -> Path:
+    return Path(__file__).resolve().parents[1] / "templates" / "cicd"
+
+
+def read_template(name: str) -> str:
+    return (template_root() / name).read_text(encoding="utf-8")
+
+
+def apply_replacements(content: str, replacements: dict[str, str]) -> str:
+    rendered = content
+    for key, value in replacements.items():
+        rendered = rendered.replace(key, value)
+    return rendered
+
+
+class ScaffoldThinCICDWorkflowsInput(BaseModel):
+    template_repo: str = Field(
+        ...,
+        description="中心模板仓库，例如 `owner/multi_dev`。",
+    )
+    template_ref: str = Field(
+        default="main",
+        description="模板仓库引用分支或 tag。",
+    )
+    python_version: str = Field(default="3.12", description="Python 版本。")
+    node_version: str = Field(default="20", description="Node.js 版本。")
+    backend_install_command: str = Field(
+        default="uv sync --extra dev",
+        description="后端依赖安装命令。",
+    )
+    backend_test_command: str = Field(
+        default="uv run pytest -q",
+        description="CI 后端检查命令。",
+    )
+    backend_verify_command: str = Field(
+        default="uv run pytest -q",
+        description="Deploy 前后端校验命令。",
+    )
+    frontend_workdir: str = Field(
+        default="frontend",
+        description="前端目录；无前端时传空字符串。",
+    )
+    frontend_install_command: str = Field(
+        default="npm install",
+        description="前端安装命令。",
+    )
+    frontend_build_command: str = Field(
+        default="npm run build",
+        description="前端构建命令。",
+    )
+    remote_deploy_command: str = Field(
+        default="bash scripts/deploy.sh",
+        description="远端部署命令。",
+    )
+
+
+class ScaffoldThinCICDWorkflowsTool(BaseTool):
+    name: str = "scaffold_thin_cicd_workflows"
+    description: str = (
+        "在目标项目中生成两个超薄 GitHub Actions workflow，"
+        "统一引用 multi_dev 中央模板仓库的 reusable workflows。"
+    )
+    args_schema: Type[BaseModel] = ScaffoldThinCICDWorkflowsInput
+
+    def _run(
+        self,
+        template_repo: str,
+        template_ref: str = "main",
+        python_version: str = "3.12",
+        node_version: str = "20",
+        backend_install_command: str = "uv sync --extra dev",
+        backend_test_command: str = "uv run pytest -q",
+        backend_verify_command: str = "uv run pytest -q",
+        frontend_workdir: str = "frontend",
+        frontend_install_command: str = "npm install",
+        frontend_build_command: str = "npm run build",
+        remote_deploy_command: str = "bash scripts/deploy.sh",
+    ) -> str:
+        root = target_repository_root()
+        workflows_dir = root / ".github" / "workflows"
+        workflows_dir.mkdir(parents=True, exist_ok=True)
+
+        replacements = {
+            "__TEMPLATE_REPO__": template_repo,
+            "__TEMPLATE_REF__": template_ref,
+            "__PYTHON_VERSION__": python_version,
+            "__NODE_VERSION__": node_version,
+            "__BACKEND_INSTALL_COMMAND__": backend_install_command,
+            "__BACKEND_TEST_COMMAND__": backend_test_command,
+            "__BACKEND_VERIFY_COMMAND__": backend_verify_command,
+            "__FRONTEND_WORKDIR__": frontend_workdir,
+            "__FRONTEND_INSTALL_COMMAND__": frontend_install_command,
+            "__FRONTEND_BUILD_COMMAND__": frontend_build_command,
+            "__REMOTE_DEPLOY_COMMAND__": remote_deploy_command,
+        }
+
+        ci_path = workflows_dir / "ci.yml"
+        deploy_path = workflows_dir / "deploy.yml"
+
+        ci_path.write_text(
+            apply_replacements(read_template("ci.thin.yml"), replacements),
+            encoding="utf-8",
+        )
+        deploy_path.write_text(
+            apply_replacements(read_template("deploy.thin.yml"), replacements),
+            encoding="utf-8",
+        )
+
+        return (
+            "已生成超薄 CI/CD workflows：\n"
+            f"- {ci_path}\n"
+            f"- {deploy_path}\n"
+            f"- template_repo: {template_repo}\n"
+            f"- template_ref: {template_ref}"
+        )

--- a/src/multi_dev/tools/git_github_tools.py
+++ b/src/multi_dev/tools/git_github_tools.py
@@ -915,7 +915,10 @@ class GitHubCreateOrUpdatePRTool(BaseTool):
 class GitHubMergePRInput(BaseModel):
     pr_number: int = Field(..., ge=1, description="PR 编号。")
     merge_method: str = Field(default="squash", description="merge / squash / rebase。")
-    delete_branch: bool = Field(default=True, description="合并后是否删除远端分支。")
+    delete_branch: bool = Field(
+        default=False,
+        description="合并后是否删除远端分支。默认保留，只有用户明确要求时才删除。",
+    )
 
 
 class GitHubReviewPRInput(BaseModel):
@@ -996,6 +999,7 @@ class GitHubMergePRTool(BaseTool):
     name: str = "github_merge_pr"
     description: str = (
         "执行真实 GitHub PR merge，并更新 `outputs/github_state.json`。"
+        "默认保留远端分支，方便用户回看 node 的改动；只有显式传入 `delete_branch=true` 才会删除。"
     )
     args_schema: Type[BaseModel] = GitHubMergePRInput
 
@@ -1003,7 +1007,7 @@ class GitHubMergePRTool(BaseTool):
         self,
         pr_number: int,
         merge_method: str = "squash",
-        delete_branch: bool = True,
+        delete_branch: bool = False,
     ) -> str:
         owner, repo = repo_state()
         pr = github_api_request(

--- a/src/multi_dev/tools/repo_execution_tools.py
+++ b/src/multi_dev/tools/repo_execution_tools.py
@@ -269,6 +269,10 @@ def bootstrap_template_targets_for_node(node_name: str) -> tuple[str, ...]:
         "tests",
         "tests/__init__.py",
         "tests/smoke_test.py",
+        ".github",
+        ".github/workflows",
+        ".github/workflows/ci.yml",
+        ".github/workflows/deploy.yml",
     )
 
     if node_name == "backend_node":


### PR DESCRIPTION
## 本次改动
- 增加 reusable CI / Deploy workflows，作为 `multi_dev` 中央模板
- 增加超薄 workflow 模板与生成工具
- 调整 GitHub merge 默认行为：合并后默认保留分支
- 补充 `.gitignore`，忽略 `outputs/` 与 `.venv/`

## 验证
- `uv run python -m compileall src`
- `ScaffoldThinCICDWorkflowsTool` 生成两张超薄 workflow 验证通过

## 价值
以后新项目只需要生成两张超薄 workflow，不再重复写整套 CI/CD。
