### PR TITLE
feat: add mature parallel dispatch lanes

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,16 @@ This command initializes the multi-dev Crew, assembles the agents, and writes st
 - `outputs/backend_node.md`
 - `outputs/frontend_node.md`
 - `outputs/tester_node.md`
+- `outputs/node_lanes/*.md`（当同类 node 池大小大于 1 时）
 - `outputs/pr_drafts.md`
 - `outputs/execution_summary.md`
 - `outputs/execution_log.jsonl`
 - `outputs/github_state.json`
 - `outputs/node_workspaces.json`
+- `outputs/dispatch_rounds.json`
+- `outputs/work_items.json`
+- `outputs/pr_bindings.json`
+- `outputs/ownership_rules.json`
 - `outputs/github_automation.md`
 - `outputs/reviewer_audit.md`
 - `outputs/master_decision.md`
@@ -73,6 +78,29 @@ For stronger role isolation, you can also set comma-separated path scopes:
 
 When these are set, write tools reject edits outside the assigned prefixes.
 In `write` mode, the latest `outputs/master_dispatch.md` also acts as a dynamic approval layer: if `master` explicitly approves concrete `targets` for a node in `dispatch_contract.work_items`, that node may write those paths during the current run even when they are outside its static env prefix. This lets `master` truly authorize one-round bootstrap targets such as `tests/` without permanently widening the node's scope.
+
+## Mature Parallel Dispatch
+
+`multi_dev` 现在已经进入可运行的并行执行形态，不再只是蓝图：
+
+- `master` 在 `dispatch_contract.work_items` 中可以为同类 node 派发多个 work item
+- 每个 work item 现在支持 `worker_lane`，用于把任务绑定到具体执行 lane，例如 `backend_node__1`
+- backend / frontend lane 可以并行执行；tester lane 在依赖 backend/frontend 输出时会自动后置收口
+- 每个 lane 都有自己独立的 worktree、branch、PR 绑定；运行态会持续写入：
+  - `outputs/dispatch_rounds.json`
+  - `outputs/work_items.json`
+  - `outputs/pr_bindings.json`
+  - `outputs/ownership_rules.json`
+
+可通过环境变量控制同类 node 池大小：
+
+```bash
+CREW_BACKEND_POOL_SIZE=2
+CREW_FRONTEND_POOL_SIZE=2
+CREW_TESTER_POOL_SIZE=2
+```
+
+如果 `master_dispatch.md` 漏写了 `worker_lane`，框架会在 `master_dispatch` 落盘后做一次正规化分配，避免多个 lane 抢同一个 work item。
 
 ## First-Version GitHub Integration
 
@@ -178,6 +206,20 @@ Important:
 
 - This is no longer only a planning shell: with valid GitHub credentials, the first version can perform **real** repo / issue / branch / worktree / commit / push / PR / merge actions.
 - It is still **not** a full remote runner platform yet: there are no isolated cloud runners, no automatic sandbox provisioning, and no production-grade permission model.
+
+## Parallel Dispatch Blueprint
+
+面向更进一步演进的“单 `master` + 多 backend / frontend / tester node 并行协作”设计蓝图已写入：
+
+- `docs/parallel_dispatch_blueprint.md`
+
+这份蓝图重点定义了：
+
+- `work_item` 状态机
+- `issue ↔ node ↔ branch ↔ worktree ↔ PR` 映射
+- ownership / 路径授权规则
+- 新项目 bootstrap 与已有项目迭代的并行调度差异
+- 建议新增的运行态文件与代码挂载点
 
 ## Understanding Your Crew
 

--- a/docs/parallel_dispatch_blueprint.md
+++ b/docs/parallel_dispatch_blueprint.md
@@ -1,0 +1,327 @@
+# 多 Node 并行调度蓝图（第一版）
+
+## 1. 目标
+
+当前 `multi_dev` 已具备单 `master`、单 `backend_node`、单 `frontend_node`、单 `tester_node`、单 `reviewer` 的基础链路。下一阶段目标不是改成“更多 agent 名字”，而是把系统升级为：
+
+- 单入口：仍然只和 `master` 交互
+- 多执行者：允许多个后端 / 前端 / 测试 node 并行工作
+- 真隔离：每个 node 绑定自己的 `issue ↔ branch ↔ worktree ↔ PR`
+- 真审查：`reviewer` 负责审查，`master` 决定 `MERGE / REWORK / CONTINUE_DISPATCH`
+- 真落盘：`write` 模式下必须优先写代码，不能只停在文档阶段
+
+## 2. 当前基线
+
+从现有实现可以确认：
+
+- `master` 已能调用 GitHub/Git 工具与文件工具
+- node 已能准备 branch、worktree、commit、push、创建/更新 PR
+- `reviewer` 已能读取 GitHub 状态并查看 diff 摘要
+- 写权限目前仍以 `backend_node`、`frontend_node`、`tester_node` 三类静态角色为中心
+- `outputs/github_state.json` 与 `outputs/node_workspaces.json` 已承担第一版运行态落盘职责
+
+这意味着第二版无需推倒重来，而是要把“单节点角色”升级为“节点池 + 工作项状态机”。
+
+## 3. 目标架构
+
+### 3.1 角色层
+
+- `master`
+  - 接收用户一句话需求
+  - 拆出可执行工作项
+  - 为工作项选择 node 类型与依赖顺序
+  - 决定 `MERGE / REWORK / CONTINUE_DISPATCH`
+- `reviewer`
+  - 审查 PR、diff、测试结果、状态机一致性
+  - 输出 `COMMENT / REQUEST_CHANGES / approve suggestion`
+  - 不直接拍板 merge
+- `backend_pool`
+  - 例如：`backend_node_catalog`、`backend_node_order`
+- `frontend_pool`
+  - 例如：`frontend_node_catalog`、`frontend_node_cart`
+- `tester_pool`
+  - 例如：`tester_node_api`、`tester_node_e2e`
+
+### 3.2 数据层
+
+建议把运行态从“按 node 记一份工作区”升级为“按工作项持久化”：
+
+- `dispatch_round`
+  - 一轮 master 派单的总上下文
+- `work_item`
+  - 一个可执行子任务
+- `node_assignment`
+  - 某个 work item 当前分配给哪个 node
+- `workspace_binding`
+  - 某个 node 的 branch/worktree 绑定
+- `pr_binding`
+  - work item 对应的 PR 状态
+- `ownership_rule`
+  - work item 可修改路径列表
+
+## 4. 核心状态机
+
+### 4.1 `work_item` 状态机
+
+```text
+DRAFT
+  -> READY
+  -> DISPATCHED
+  -> IN_PROGRESS
+  -> IN_REVIEW
+  -> APPROVED
+  -> MERGED
+
+DISPATCHED / IN_PROGRESS / IN_REVIEW
+  -> REWORK_REQUIRED
+  -> REDISPATCHED
+  -> IN_PROGRESS
+```
+
+建议定义：
+
+- `DRAFT`
+  - master 刚拆出来，尚未满足执行前置条件
+- `READY`
+  - 依赖满足，可派发
+- `DISPATCHED`
+  - 已绑定 node，但 node 尚未开始写
+- `IN_PROGRESS`
+  - 已创建 worktree 且出现真实写入/commit
+- `IN_REVIEW`
+  - PR 已创建或已更新，等待 reviewer/master
+- `APPROVED`
+  - 审查通过，可进入 merge 阶段
+- `MERGED`
+  - 已合入主线
+- `REWORK_REQUIRED`
+  - 被 reviewer 或 master 打回，必须继续改
+- `REDISPATCHED`
+  - 已重新绑定 node 或重新进入同一 node 的下一次执行
+
+### 4.2 `issue ↔ node ↔ branch ↔ worktree ↔ PR` 映射
+
+每个 `work_item` 必须唯一对应：
+
+- 1 个 GitHub issue
+- 1 个主责任 node
+- 1 条 branch
+- 1 个 worktree
+- 1 个当前活动 PR
+
+允许：
+
+- 一个需求拆成多个 `work_item`
+- 一个 node 在不同轮次处理多个 `work_item`
+
+不允许：
+
+- 多个活跃 `work_item` 共用同一个 branch
+- 多个 node 同时写同一个 worktree
+- 没有真实写入却把状态推进到 `IN_REVIEW`
+
+## 5. Ownership 规则
+
+并行版最关键的不是“多几个 agent”，而是“谁能改哪些文件”。
+
+### 5.1 Ownership 设计原则
+
+- 以 `work_item.targets[]` 为第一准绳
+- 以 node 类型默认前缀为第二准绳
+- `master` 可以在单轮 dispatch 中临时扩权
+- `reviewer` 发现越界路径时可直接判定 `REWORK`
+
+### 5.2 路径授权建议
+
+- 后端类 work item
+  - 允许：`src/`、`backend/`、`app/` 下经 master 批准的子路径
+- 前端类 work item
+  - 允许：`frontend/`、`web/`、`ui/` 下经 master 批准的子路径
+- 测试类 work item
+  - 允许：`tests/`、项目内测试配置、经 master 明确批准的 README/工作流文件
+
+### 5.3 冲突处理
+
+若两个 work item 目标路径重叠：
+
+- 优先由 `master` 在派单前拆分成更细的 ownership
+- 若无法拆开，则标记为有依赖关系，不进入并行
+- reviewer 发现跨 work item 改动重叠时，可要求其中一个 PR 回退重提
+
+## 6. 新项目与已有项目的调度差异
+
+### 6.1 新项目 + `write` 模式
+
+必须优先进入最小落盘路径：
+
+1. `master` 判断为 bootstrap 场景
+2. 快速生成最小执行单
+3. 至少一个 node 先完成真实写入
+4. 若本轮无真实写入，则 `master` 直接判定 `REWORK`
+
+在该模式下：
+
+- 禁止过长的前置分析链
+- 禁止 node 未经批准自行发明技术栈
+- 技术栈、目录、框架应来自：
+  - 用户明确要求
+  - `master` 在模板中的明确批准
+  - 仓库中已有事实
+
+### 6.2 已有项目迭代
+
+已有仓库时，master 可以更依赖：
+
+- 现有目录结构
+- 真实文件引用关系
+- 既有 issue / PR / CI 状态
+
+但依然必须遵守：
+
+- 未见文件不能当事实
+- 未批准路径不能写
+- 未真实写入不能假装进入开发完成阶段
+
+## 7. Reviewer 与 Master 的职责边界
+
+### 7.1 Reviewer
+
+负责判断：
+
+- 是否越界修改
+- 是否与 work item 的 targets 不一致
+- 是否存在无真实写入却宣称完成
+- 是否存在 PR 描述与真实 diff 不一致
+- 是否满足最基本测试或验证要求
+
+输出建议状态：
+
+- `COMMENT`
+- `REQUEST_CHANGES`
+- `APPROVE_SUGGESTION`
+
+### 7.2 Master
+
+负责最终决策：
+
+- `MERGE`
+  - reviewer 无阻塞问题，且依赖链满足
+- `REWORK`
+  - 任意关键路径失败、越界、无真实写入、状态机不一致
+- `CONTINUE_DISPATCH`
+  - 当前结果可接受，但仍需派发后续 work item
+
+## 8. 建议新增的运行态文件
+
+以下均为拟新增：
+
+- `outputs/dispatch_rounds.json`
+  - 记录每一轮 dispatch 摘要
+- `outputs/work_items.json`
+  - 记录 work item 状态机、依赖、targets、当前 node
+- `outputs/pr_bindings.json`
+  - 记录 issue / branch / worktree / PR 对应关系
+- `outputs/ownership_rules.json`
+  - 记录每个 work item 当前生效的路径授权
+
+现有文件继续保留并逐步收敛职责：
+
+- `outputs/github_state.json`
+- `outputs/node_workspaces.json`
+- `outputs/execution_log.jsonl`
+
+## 9. 建议新增的代码挂载点
+
+以下均为拟新增：
+
+- `src/multi_dev/models/dispatch.py`
+  - `DispatchRound`、`WorkItem`、`PRBinding`、`OwnershipRule`
+- `src/multi_dev/services/dispatch_state.py`
+  - 负责读写 `outputs/*.json`
+- `src/multi_dev/services/work_item_planner.py`
+  - 把需求拆成可并行 work item
+- `src/multi_dev/services/ownership.py`
+  - 统一判断路径是否越界
+- `src/multi_dev/services/dependency_graph.py`
+  - 计算哪些 work item 可并行、哪些必须串行
+- `src/multi_dev/tools/dispatch_state_tools.py`
+  - 暴露给 master/reviewer 的状态查询与更新工具
+
+## 10. 实现顺序建议
+
+### Phase 1：先把状态机立住
+
+- 引入 `work_item` 结构
+- 引入 `dispatch_round`
+- 用文件落盘状态，而不是只靠 markdown
+
+### Phase 2：把单节点角色升级成节点池
+
+- `backend_node` -> `backend_pool[*]`
+- `frontend_node` -> `frontend_pool[*]`
+- `tester_node` -> `tester_pool[*]`
+
+这里不一定要求先生成真实多个 Agent 方法，也可以先让 `master` 在派单合同中显式声明逻辑 node id，例如：
+
+- `backend_node.catalog`
+- `backend_node.order`
+- `frontend_node.catalog`
+
+### Phase 3：把 ownership 真接到写工具
+
+- `write_repo_file`
+- `replace_repo_text`
+- `make_repo_directory`
+
+都应同时校验：
+
+- node 类型允许范围
+- work item 批准 targets
+- 当前 dispatch round 的 ownership 规则
+
+### Phase 4：把 review/merge 决策挂到 work item 状态
+
+- reviewer 的输出更新 `work_items.json`
+- master 的 merge/rework/continue 也更新同一状态机
+- 所有 GitHub 动作都反写状态文件
+
+## 11. 第一版并行规模建议
+
+不要一开始就做无限并行，建议先支持：
+
+- 2 个后端 node
+- 2 个前端 node
+- 1 个 tester node
+- 1 个 reviewer
+
+这已经足够验证：
+
+- 并行派单
+- branch/worktree 隔离
+- ownership 防踩踏
+- reviewer 打回
+- master 合流
+
+## 12. 验收标准
+
+并行版第一阶段完成时，应至少满足：
+
+- 用户仍然只需要对 `master` 说一句需求
+- `master` 能拆出多个 work item
+- 每个 work item 都有独立的 issue / branch / worktree / PR 绑定
+- node 在 `write` 模式下会真实写文件，而不是只产出文档
+- reviewer 能按 work item 打回
+- master 能针对单个 work item 做 `merge / rework / continue`
+- 任意并行 node 越界写路径会被工具层拦截或被 reviewer 打回
+
+## 13. 推荐下一步
+
+下一步不要直接大改全部 agent prompt，建议先做最小闭环：
+
+1. 增加 `work_items.json` 与 `dispatch_rounds.json`
+2. 让 `master_dispatch.md` 同时输出结构化 work item JSON
+3. 让 `GitPrepareWorkspaceTool` 支持按 `work_item_id` 创建 branch/worktree
+4. 让写工具读取 `work_item_id -> ownership`
+5. 只挑一个真实项目跑“两后端 + 一前端 + 一测试”的 smoke run
+
+这样我们可以先把“并行调度骨架”跑通，再逐步扩成通用多节点池。

--- a/src/multi_dev/config/tasks.yaml
+++ b/src/multi_dev/config/tasks.yaml
@@ -211,6 +211,8 @@ master_intake_task:
     - 若 `github_enabled=true` 且 `execution_mode=write`，你必须把 GitHub 仓库、issue、branch、PR 当作本轮真实交付链路的一部分，而不是未来蓝图。
     - 在该模式下，GitHub 的最终决策者始终是 `master`；`reviewer` 只提供审计意见，`node` 不得自行合并。
     - 若用户没有明确指定技术栈、框架、脚手架或顶层目录，你不得在本任务中擅自引入 `FastAPI`、`Flask`、`Django`、`React`、`Vue`、`Vite`、`Next.js`、`Makefile`、`Dockerfile`、CI 工作流等实现细节。
+    - 在已有业务仓库场景下，若用户点名的是能力或界面位置（如 `/health`、Hero、购物车、smoke 测试），你必须继续用真实工具在现有目录中定位实际文件；不得因为某个你自己猜出的路径不存在，就把它写成阻塞项。
+    - 若工具已经命中了现有文件（例如 `src/**/*.py`、`frontend/src/**/*`、`tests/**/*.py`），你应优先引用这些真实文件，并在接单摘要里明确写成“已发现证据”；不要继续沿用 `frontend/index.html`、`frontend/cart.js`、`tests/smoke_test.py` 之类未被当前轮工具命中的猜测路径。
     - 在空仓 `write` 场景下，唯一允许的默认模板是中性最小骨架：根级 `pyproject.toml`、`src/{bootstrap_package_name}/`、可选 `frontend/`、`tests/`。不得扩写为 node 同名目录、框架特定目录或额外工具链。
     - 若 `bootstrap_fast_track=true`，你在本任务中最多只可点名以下中性目标：`pyproject.toml`、`src/{bootstrap_package_name}/`、`frontend/`、`tests/`；不得继续细化为 `models.py`、`main.py`、`Blueprint`、`fetch('/api/...')`、`pytest` 用例名等实现级细节。
   expected_output: >
@@ -281,10 +283,12 @@ master_dispatch_task:
     - 在 `write` 模式下，若需求本身是“创建/初始化/生成骨架”，你必须优先下发可执行的小步真实写入项，而不是只输出文档化计划；此时 `拟新增文件` / `拟新增目录` 应被视为待执行目标，而不是默认阻塞。
     - 在 `write` 模式下，不得把“谨慎”“待确认”“可后续再做”当作普遍性拒写理由；除非路径越界、需求缺失、或会覆盖现有无关资产，否则应先执行，再交给 reviewer 打回或要求修订。
     - 若 `github_enabled=true` 且 `execution_mode=write`，你必须先调用 `github_bootstrap_repo(...)` 确保仓库存在且本地 repo / remote / 默认分支就绪，再为每个实际派发项调用 `github_create_issue(...)` 创建真实 issue。
+    - 在已有业务仓库场景下，若某项 work item 的目标属于现有目录（如 `src/**`、`frontend/**`、`tests/**`），你必须先基于真实工具结果把它收敛到可执行的现有文件或已批准的新文件；不要只派目录级目标后让 node 自己猜。
     - 若 `cicd_enabled=true`，且用户本轮明确要求“CI/CD / 部署 / GitHub Actions / 自动发布”，你必须在派发前调用 `github_sync_cicd_secrets(...)`，把部署相关 secrets 真正写入当前 GitHub repo；不得只在文档里说“后续再配置”。
     - 在该模式下，你为每个被派发的 work item 都必须给出真实 `branch_name`，并建议唯一 `worktree_path`；这些值必须写入 `dispatch_contract.work_items`。
     - 在并行模式下，同一个 `node` 类型下允许出现多个逻辑执行单元；因此 `dispatch_contract.work_items` 中每一项都必须补充 `work_item_id` 与 `logical_node_id`。例如同为 `backend_node`，可以拆成 `backend_node.catalog`、`backend_node.order`。
     - 在该模式下，`dispatch_contract.work_items` 中每一项除现有字段外，还必须补充：`work_item_id`、`logical_node_id`、`worker_lane`、`github_issue_number`、`branch_name`、`worktree_path`、`pr_title`、`depends_on`。
+    - 在已有业务仓库场景下，若你已经通过工具看到了具体文件，`dispatch_contract.work_items[*].targets` 应尽量写成具体文件路径，而不是宽泛目录；同时可附加 `candidate_files` 供 node 直接读取，不得让 node 在现有仓库里凭空新建平行实现。
     - 若 `cicd_enabled=true` 且用户明确要求 CI/CD，本轮允许新增的中性 CI/CD 目标仅限：`.github/workflows/ci.yml`、`.github/workflows/deploy.yml`、`scripts/deploy.sh`。除非用户明确批准，否则不得擅自扩写为 Docker、Kubernetes、Terraform、Helm、ArgoCD 等额外体系。
     - 若用户已明确给出最小骨架路径清单，则调度单必须优先围绕这些路径派发，不得因为上游草稿更“丰富”就扩写为额外目标。
     - 若 `bootstrap_fast_track=true`，你必须跳过冗长 issue/workspace 复述，直接生成“最小真实写入调度单”；优先让 node 在本轮落盘，不要把篇幅花在背景说明上。
@@ -355,6 +359,8 @@ backend_node_task:
     - 若已派发给 `backend_node` 且 `execution_mode=write`，必须先调用真实工具完成写入，再写工作卡；不得把计划写在执行前面冒充结果。
     - 若同一轮有多个 `backend_node` work item 被派发给你，你必须逐个 work item 独立执行，不得把多个 work item 混到同一条 branch、同一个 worktree 或同一个 PR 中。
     - 若 `github_enabled=true` 且 `execution_mode=write`，你必须按 work item 如下顺序执行：1) 读取该 work item 的 `work_item_id`、`logical_node_id`、`worker_lane`、`github_issue_number`、`branch_name`、`worktree_path`；2) 仅接手 `worker_lane` 等于当前执行 lane 的项；3) 调用 `git_prepare_node_workspace(node_name=<当前执行 lane>, work_item_id=..., logical_node_id=..., ...)`；4) 在该 worktree 中调用文件写入工具；5) 调用 `git_commit_and_push(node_name=<当前执行 lane>, work_item_id=..., ...)`；6) 调用 `github_create_or_update_pr(node_name=<当前执行 lane>, work_item_id=..., logical_node_id=..., ...)`。不得跳过 branch / worktree / PR。
+    - 在已有业务仓库场景下，若 work item 的 `targets` 是目录或 glob（如 `src/**`），你必须先调用 `list_repo_files(...)` 与 `read_repo_file(...)` 找到真实现有文件，再修改该文件；只有在调度单明确批准 `拟新增文件` 时，才可新建文件。没有先做真实读取，不得直接宣称“未找到相关文件”或另起平行实现。
+    - 若 `dispatch_contract.work_items[*]` 提供了 `candidate_files`，你必须优先读取并修改这些文件；除非这些文件经真实读取确认无法承载目标，否则不得绕开它们另建新文件。
     - 若 `cicd_enabled=true` 且你被派发了 `.github/workflows/deploy.yml` 或 `scripts/deploy.sh`，必须直接落盘这些 CI/CD 文件；它们属于本轮真实交付，不是未来蓝图。
     - 在该场景下，部署脚本必须优先使用 `ssh` + `git pull` + 进程重启这一最小链路；除非用户明确要求，否则不要擅自引入 Docker、Kubernetes 或云原生编排。
     - 若 `bootstrap_fast_track=true`，且本轮接手的是创建型骨架任务，你的第一批有效动作必须是 `make_repo_directory` / `write_repo_file`；不要先输出大段分析、计划或验证矩阵。
@@ -407,6 +413,8 @@ frontend_node_task:
     - 在 `write` 模式下，若已接手明确的创建型前端 issue，却没有调用任何写入工具，你必须写出具体硬阻塞原因；不得用抽象谨慎理由替代执行。
     - 若同一轮有多个 `frontend_node` work item 被派发给你，你必须逐个 work item 独立执行，不得把多个 work item 混到同一条 branch、同一个 worktree 或同一个 PR 中。
     - 若 `github_enabled=true` 且 `execution_mode=write`，你必须按 work item 如下顺序执行：1) 读取该 work item 的 `work_item_id`、`logical_node_id`、`worker_lane`、`github_issue_number`、`branch_name`、`worktree_path`；2) 仅接手 `worker_lane` 等于当前执行 lane 的项；3) 调用 `git_prepare_node_workspace(node_name=<当前执行 lane>, work_item_id=..., logical_node_id=..., ...)`；4) 在该 worktree 中调用文件写入工具；5) 调用 `git_commit_and_push(node_name=<当前执行 lane>, work_item_id=..., ...)`；6) 调用 `github_create_or_update_pr(node_name=<当前执行 lane>, work_item_id=..., logical_node_id=..., ...)`。
+    - 在已有业务仓库场景下，若 work item 的 `targets` 是目录或 glob（如 `frontend/**`），你必须先调用 `list_repo_files(...)` 与 `read_repo_file(...)` 找到真实现有文件，再修改该文件；只有在调度单明确批准 `拟新增文件` 时，才可新建文件。若仓库里已存在前端入口文件，不得另起一个平行前端实现。
+    - 若 `dispatch_contract.work_items[*]` 提供了 `candidate_files`，你必须优先读取并修改这些文件；除非这些文件经真实读取确认无法承载目标，否则不得绕开它们另建新文件。
     - 若 `cicd_enabled=true` 且你被派发了前端可见的 CI/CD 目标（如发布页、静态校验页或需要配合的 workflow 文案文件），只可处理 master 已批准的那些具体路径；不得擅自扩写额外前端工程化体系。
     - 若 `bootstrap_fast_track=true`，你应优先落盘最小文件集合，再补充工作卡；不要把大段解释放在真实写入前面。
     - 若 `bootstrap_fast_track=true`，你只可落盘 `frontend/index.html`、`frontend/app.js`、`frontend/styles.css`。若上游派单写成 `package.json`、`vite.config.js`、`src/App.vue`、`src/main.tsx` 或其他路径，你必须降级为这三个中性模板目标并继续执行，不得因此停写。
@@ -456,6 +464,8 @@ tester_node_task:
     - 在 `write` 模式下，若 `tester_node` 接手的是创建型测试骨架任务（例如 `tests/`、`tests/__init__.py`、smoke 脚本、校验脚本），必须先调用 `make_repo_directory` / `write_repo_file` 完成真实创建，再写验证矩阵；不得只输出验证文档而不落盘。
     - 若同一轮有多个 `tester_node` work item 被派发给你，你必须逐个 work item 独立执行，不得把多个 work item 混到同一条 branch、同一个 worktree 或同一个 PR 中。
     - 若 `github_enabled=true` 且 `execution_mode=write`，你必须按 work item 如下顺序执行：1) 读取该 work item 的 `work_item_id`、`logical_node_id`、`worker_lane`、`github_issue_number`、`branch_name`、`worktree_path`；2) 仅接手 `worker_lane` 等于当前执行 lane 的项；3) 调用 `git_prepare_node_workspace(node_name=<当前执行 lane>, work_item_id=..., logical_node_id=..., ...)`；4) 在该 worktree 中调用文件写入工具；5) 调用 `git_commit_and_push(node_name=<当前执行 lane>, work_item_id=..., ...)`；6) 调用 `github_create_or_update_pr(node_name=<当前执行 lane>, work_item_id=..., logical_node_id=..., ...)`。
+    - 在已有业务仓库场景下，若 work item 的 `targets` 是目录或 glob（如 `tests/**`），你必须先调用 `list_repo_files(...)` 与 `read_repo_file(...)` 找到真实现有测试文件，再修改该文件；只有在调度单明确批准 `拟新增文件` 时，才可新建文件。
+    - 若 `dispatch_contract.work_items[*]` 提供了 `candidate_files`，你必须优先读取并修改这些文件；除非这些文件经真实读取确认无法承载目标，否则不得绕开它们另建新文件。
     - 若 `cicd_enabled=true` 且你被派发了 `.github/workflows/ci.yml`，必须直接落盘一个真实可运行的 GitHub Actions CI workflow；其检查命令必须以仓库可见证据为准，不得凭空假设不存在的工具链。
     - 若仓库没有真实测试基建证据，不得凭空创建复杂测试体系；最多只可创建轻量 smoke 脚本或文档化验证脚本，并在输出中说明。
     - 若 `execution_mode=write` 且你确实新增或修改了轻量验证文件，可在产出中列出“实际修改文件”，但不得把尚未运行的验证写成“已通过”。

--- a/src/multi_dev/config/tasks.yaml
+++ b/src/multi_dev/config/tasks.yaml
@@ -283,7 +283,8 @@ master_dispatch_task:
     - 若 `github_enabled=true` 且 `execution_mode=write`，你必须先调用 `github_bootstrap_repo(...)` 确保仓库存在且本地 repo / remote / 默认分支就绪，再为每个实际派发项调用 `github_create_issue(...)` 创建真实 issue。
     - 若 `cicd_enabled=true`，且用户本轮明确要求“CI/CD / 部署 / GitHub Actions / 自动发布”，你必须在派发前调用 `github_sync_cicd_secrets(...)`，把部署相关 secrets 真正写入当前 GitHub repo；不得只在文档里说“后续再配置”。
     - 在该模式下，你为每个被派发的 work item 都必须给出真实 `branch_name`，并建议唯一 `worktree_path`；这些值必须写入 `dispatch_contract.work_items`。
-    - 在该模式下，`dispatch_contract.work_items` 中每一项除现有字段外，还必须补充：`github_issue_number`、`branch_name`、`worktree_path`、`pr_title`。
+    - 在并行模式下，同一个 `node` 类型下允许出现多个逻辑执行单元；因此 `dispatch_contract.work_items` 中每一项都必须补充 `work_item_id` 与 `logical_node_id`。例如同为 `backend_node`，可以拆成 `backend_node.catalog`、`backend_node.order`。
+    - 在该模式下，`dispatch_contract.work_items` 中每一项除现有字段外，还必须补充：`work_item_id`、`logical_node_id`、`worker_lane`、`github_issue_number`、`branch_name`、`worktree_path`、`pr_title`、`depends_on`。
     - 若 `cicd_enabled=true` 且用户明确要求 CI/CD，本轮允许新增的中性 CI/CD 目标仅限：`.github/workflows/ci.yml`、`.github/workflows/deploy.yml`、`scripts/deploy.sh`。除非用户明确批准，否则不得擅自扩写为 Docker、Kubernetes、Terraform、Helm、ArgoCD 等额外体系。
     - 若用户已明确给出最小骨架路径清单，则调度单必须优先围绕这些路径派发，不得因为上游草稿更“丰富”就扩写为额外目标。
     - 若 `bootstrap_fast_track=true`，你必须跳过冗长 issue/workspace 复述，直接生成“最小真实写入调度单”；优先让 node 在本轮落盘，不要把篇幅花在背景说明上。
@@ -294,7 +295,7 @@ master_dispatch_task:
     - 若上游草稿把需求扩写成框架、工具链、node 同名目录或额外基础设施，而用户并未明确要求，你必须在本任务中剥离这些内容，只保留最小落盘目标。
     - 若 `round_index` 大于 1，且 `retry_nodes` 不是 `all`，你必须只派发这些 node，并仅围绕上一轮失败项或继续项生成调度单。
     - 你的输出末尾必须附带一个可机读的 `dispatch_contract` JSON 代码块，键至少包含：`round_index`、`mode`、`active_nodes`、`inactive_nodes`、`work_items`、`user_interface`。
-    - `work_items` 中的每一项必须至少包含：`issue_id`、`node`、`action`、`targets`、`must_use_tools`、`done_when`。
+    - `work_items` 中的每一项必须至少包含：`work_item_id`、`logical_node_id`、`worker_lane`、`issue_id`、`node`、`action`、`targets`、`must_use_tools`、`done_when`、`depends_on`。
     - 当你把某个具体 `targets` 写进 `dispatch_contract.work_items` 时，这些 `targets` 就是该 node 本轮被 master 批准的真实执行边界；请只写你愿意让 node 真正落盘的路径。
     - 若 `bootstrap_mode=new` 且 `execution_mode=write`，本轮 `dispatch_contract.work_items` 总数不得超过 3 个，且至少 1 个 work item 必须能在本轮直接触发真实文件写入。
   expected_output: >
@@ -352,7 +353,8 @@ backend_node_task:
     - 若某个派单项的 `targets` 落在 `tests/`、`tests/**` 或 `scripts/**`，应视为 tester 范围，你必须拒收并在工作卡中明确写出“应由 tester_node 接手”；不要为了求稳把测试骨架吞进 backend。
     - 你必须先从 `master_dispatch` 上下文中的 `dispatch_contract` 识别当前轮是否派发给 `backend_node`；若未派发，则明确输出 `skipped`，不得擅自执行。
     - 若已派发给 `backend_node` 且 `execution_mode=write`，必须先调用真实工具完成写入，再写工作卡；不得把计划写在执行前面冒充结果。
-    - 若 `github_enabled=true` 且 `execution_mode=write`，你必须按如下顺序执行：1) 读取 `dispatch_contract` 中分配给你的 `github_issue_number`、`branch_name`、`worktree_path`；2) 调用 `git_prepare_node_workspace(...)`；3) 在该 worktree 中调用文件写入工具；4) 调用 `git_commit_and_push(...)`；5) 调用 `github_create_or_update_pr(...)`。不得跳过 branch / worktree / PR。
+    - 若同一轮有多个 `backend_node` work item 被派发给你，你必须逐个 work item 独立执行，不得把多个 work item 混到同一条 branch、同一个 worktree 或同一个 PR 中。
+    - 若 `github_enabled=true` 且 `execution_mode=write`，你必须按 work item 如下顺序执行：1) 读取该 work item 的 `work_item_id`、`logical_node_id`、`worker_lane`、`github_issue_number`、`branch_name`、`worktree_path`；2) 仅接手 `worker_lane` 等于当前执行 lane 的项；3) 调用 `git_prepare_node_workspace(node_name=<当前执行 lane>, work_item_id=..., logical_node_id=..., ...)`；4) 在该 worktree 中调用文件写入工具；5) 调用 `git_commit_and_push(node_name=<当前执行 lane>, work_item_id=..., ...)`；6) 调用 `github_create_or_update_pr(node_name=<当前执行 lane>, work_item_id=..., logical_node_id=..., ...)`。不得跳过 branch / worktree / PR。
     - 若 `cicd_enabled=true` 且你被派发了 `.github/workflows/deploy.yml` 或 `scripts/deploy.sh`，必须直接落盘这些 CI/CD 文件；它们属于本轮真实交付，不是未来蓝图。
     - 在该场景下，部署脚本必须优先使用 `ssh` + `git pull` + 进程重启这一最小链路；除非用户明确要求，否则不要擅自引入 Docker、Kubernetes 或云原生编排。
     - 若 `bootstrap_fast_track=true`，且本轮接手的是创建型骨架任务，你的第一批有效动作必须是 `make_repo_directory` / `write_repo_file`；不要先输出大段分析、计划或验证矩阵。
@@ -403,7 +405,8 @@ frontend_node_task:
     - `未找到匹配路径。` 只表示尚未存在；它不能证明目录已存在，但在“用户明确要求新建前端模块”且 master 已批准的场景下，可支持“允许创建该新路径”的结论。
     - 不得罗列你未实际查询到的文件名或工具调用；只能复述真实工具返回里的路径。
     - 在 `write` 模式下，若已接手明确的创建型前端 issue，却没有调用任何写入工具，你必须写出具体硬阻塞原因；不得用抽象谨慎理由替代执行。
-    - 若 `github_enabled=true` 且 `execution_mode=write`，你必须按如下顺序执行：1) 读取 `dispatch_contract` 中分配给你的 `github_issue_number`、`branch_name`、`worktree_path`；2) 调用 `git_prepare_node_workspace(...)`；3) 在该 worktree 中调用文件写入工具；4) 调用 `git_commit_and_push(...)`；5) 调用 `github_create_or_update_pr(...)`。
+    - 若同一轮有多个 `frontend_node` work item 被派发给你，你必须逐个 work item 独立执行，不得把多个 work item 混到同一条 branch、同一个 worktree 或同一个 PR 中。
+    - 若 `github_enabled=true` 且 `execution_mode=write`，你必须按 work item 如下顺序执行：1) 读取该 work item 的 `work_item_id`、`logical_node_id`、`worker_lane`、`github_issue_number`、`branch_name`、`worktree_path`；2) 仅接手 `worker_lane` 等于当前执行 lane 的项；3) 调用 `git_prepare_node_workspace(node_name=<当前执行 lane>, work_item_id=..., logical_node_id=..., ...)`；4) 在该 worktree 中调用文件写入工具；5) 调用 `git_commit_and_push(node_name=<当前执行 lane>, work_item_id=..., ...)`；6) 调用 `github_create_or_update_pr(node_name=<当前执行 lane>, work_item_id=..., logical_node_id=..., ...)`。
     - 若 `cicd_enabled=true` 且你被派发了前端可见的 CI/CD 目标（如发布页、静态校验页或需要配合的 workflow 文案文件），只可处理 master 已批准的那些具体路径；不得擅自扩写额外前端工程化体系。
     - 若 `bootstrap_fast_track=true`，你应优先落盘最小文件集合，再补充工作卡；不要把大段解释放在真实写入前面。
     - 若 `bootstrap_fast_track=true`，你只可落盘 `frontend/index.html`、`frontend/app.js`、`frontend/styles.css`。若上游派单写成 `package.json`、`vite.config.js`、`src/App.vue`、`src/main.tsx` 或其他路径，你必须降级为这三个中性模板目标并继续执行，不得因此停写。
@@ -451,7 +454,8 @@ tester_node_task:
     - 当 `execution_mode` 为 `write` 时，若 master 调度单明确批准了轻量测试占位文件、验证脚本或测试目录创建，你应执行创建；不要因为 `tests/` 当前不存在而默认拒绝。
     - 在 `write` 模式下，`tester_node` 默认拥有 `tests/**`、`scripts/**`、轻量验证脚本和 smoke 文件的落盘职责；只要 master 调度单已批准这些目标，就应直接写入。
     - 在 `write` 模式下，若 `tester_node` 接手的是创建型测试骨架任务（例如 `tests/`、`tests/__init__.py`、smoke 脚本、校验脚本），必须先调用 `make_repo_directory` / `write_repo_file` 完成真实创建，再写验证矩阵；不得只输出验证文档而不落盘。
-    - 若 `github_enabled=true` 且 `execution_mode=write`，你必须按如下顺序执行：1) 读取 `dispatch_contract` 中分配给你的 `github_issue_number`、`branch_name`、`worktree_path`；2) 调用 `git_prepare_node_workspace(...)`；3) 在该 worktree 中调用文件写入工具；4) 调用 `git_commit_and_push(...)`；5) 调用 `github_create_or_update_pr(...)`。
+    - 若同一轮有多个 `tester_node` work item 被派发给你，你必须逐个 work item 独立执行，不得把多个 work item 混到同一条 branch、同一个 worktree 或同一个 PR 中。
+    - 若 `github_enabled=true` 且 `execution_mode=write`，你必须按 work item 如下顺序执行：1) 读取该 work item 的 `work_item_id`、`logical_node_id`、`worker_lane`、`github_issue_number`、`branch_name`、`worktree_path`；2) 仅接手 `worker_lane` 等于当前执行 lane 的项；3) 调用 `git_prepare_node_workspace(node_name=<当前执行 lane>, work_item_id=..., logical_node_id=..., ...)`；4) 在该 worktree 中调用文件写入工具；5) 调用 `git_commit_and_push(node_name=<当前执行 lane>, work_item_id=..., ...)`；6) 调用 `github_create_or_update_pr(node_name=<当前执行 lane>, work_item_id=..., logical_node_id=..., ...)`。
     - 若 `cicd_enabled=true` 且你被派发了 `.github/workflows/ci.yml`，必须直接落盘一个真实可运行的 GitHub Actions CI workflow；其检查命令必须以仓库可见证据为准，不得凭空假设不存在的工具链。
     - 若仓库没有真实测试基建证据，不得凭空创建复杂测试体系；最多只可创建轻量 smoke 脚本或文档化验证脚本，并在输出中说明。
     - 若 `execution_mode=write` 且你确实新增或修改了轻量验证文件，可在产出中列出“实际修改文件”，但不得把尚未运行的验证写成“已通过”。

--- a/src/multi_dev/crew.py
+++ b/src/multi_dev/crew.py
@@ -165,6 +165,10 @@ class MultiDev:
     def bootstrap_fast_track_enabled(self) -> bool:
         return self.bootstrap_mode() == "new" and self.execution_mode() == "write"
 
+    def direct_dispatch_enabled(self) -> bool:
+        value = os.getenv("CREW_DIRECT_DISPATCH", "").strip().lower()
+        return value in {"1", "true", "yes", "on"}
+
     def node_allowed_prefixes(self, env_name: str) -> tuple[str, ...]:
         raw_value = os.getenv(env_name, "").strip()
         if not raw_value:
@@ -360,7 +364,6 @@ class MultiDev:
         return Agent(
             config=self.agents_config["master_manager"],  # type: ignore[index]
             llm=self.shared_llm(),
-            tools=self.master_tools(),
             verbose=True,
             allow_delegation=True,
             reasoning=False,
@@ -669,9 +672,8 @@ class MultiDev:
 
         planning_enabled = self.planning_enabled()
         output_log_file = os.getenv("CREW_OUTPUT_LOG_FILE") or None
-        run_mode = self.run_mode()
-        process = Process.sequential if run_mode == "fast" else Process.hierarchical
-        manager_agent = None if run_mode == "fast" else self.master_manager()
+        process = Process.sequential
+        manager_agent = None
 
         master_controller = self.master_controller()
         repo_analyst = self.repo_analyst()
@@ -705,7 +707,7 @@ class MultiDev:
         )
 
         master_intake_context: list[Task] = []
-        if not self.bootstrap_fast_track_enabled():
+        if not self.bootstrap_fast_track_enabled() and not self.direct_dispatch_enabled():
             master_intake_context = [repo_analysis_task, module_boundary_task]
         master_intake_task = self.configured_task(
             "master_intake_task",
@@ -715,7 +717,7 @@ class MultiDev:
         )
 
         master_dispatch_context = [master_intake_task]
-        if not self.bootstrap_fast_track_enabled():
+        if not self.bootstrap_fast_track_enabled() and not self.direct_dispatch_enabled():
             master_dispatch_context.extend([issue_drafting_task, workspace_plan_task])
         master_dispatch_task = self.configured_task(
             "master_dispatch_task",
@@ -837,7 +839,7 @@ class MultiDev:
             name="master_decision_task",
         )
 
-        if self.bootstrap_fast_track_enabled():
+        if self.bootstrap_fast_track_enabled() or self.direct_dispatch_enabled():
             tasks = [
                 master_intake_task,
                 master_dispatch_task,

--- a/src/multi_dev/crew.py
+++ b/src/multi_dev/crew.py
@@ -1,6 +1,8 @@
 import json
+import hashlib
 import os
 import re
+from pathlib import Path
 
 from crewai import Agent, Crew, LLM, Process, Task
 from crewai.agents.agent_builder.base_agent import BaseAgent
@@ -51,6 +53,65 @@ def lane_name_for_node(base_node_name: str, lane_index: int) -> str:
     return f"{base_node_name}__{lane_index}"
 
 
+def repo_workspace_slug(repo_root: Path) -> str:
+    digest = hashlib.sha1(str(repo_root).encode("utf-8")).hexdigest()[:8]
+    name = re.sub(r"[^0-9A-Za-z._-]+", "-", repo_root.name).strip("-")
+    return f"{name or 'repo'}-{digest}"
+
+
+def sanitized_fragment(value: str) -> str:
+    cleaned = str(value).replace("/", "--")
+    cleaned = re.sub(r"[^0-9A-Za-z._-]+", "-", cleaned).strip("-")
+    return cleaned or "task"
+
+
+def default_worktree_path_for(
+    node_name: str,
+    work_item_id: str,
+    logical_node_id: str,
+    branch_name: str,
+) -> str:
+    repo_root = Path(
+        os.getenv("TARGET_REPOSITORY_ROOT", str(Path.cwd()))
+    ).expanduser().resolve()
+    target = (
+        Path(__file__).resolve().parents[3]
+        / "outputs"
+        / "worktrees"
+        / repo_workspace_slug(repo_root)
+        / f"{node_name}-{sanitized_fragment(work_item_id or logical_node_id or branch_name)}"
+    )
+    return str(target.resolve())
+
+
+def load_issue_bindings() -> list[dict[str, object]]:
+    path = Path(__file__).resolve().parents[3] / "outputs" / "github_state.json"
+    if not path.exists():
+        return []
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return []
+    issues = payload.get("issues", [])
+    if not isinstance(issues, list):
+        return []
+    return [issue for issue in issues if isinstance(issue, dict)]
+
+
+def normalize_worker_lane_name(
+    node_name: str,
+    logical_node_id: str,
+    raw_worker_lane: str,
+    lane_index: int,
+) -> str:
+    candidate = raw_worker_lane.strip()
+    if candidate.startswith(f"{node_name}__") or candidate == node_name:
+        return candidate
+    if logical_node_id.startswith(f"{node_name}__"):
+        return logical_node_id.split(".", 1)[0]
+    return lane_name_for_node(node_name, lane_index)
+
+
 def normalize_master_dispatch_artifact_callback(*_args, **_kwargs) -> None:
     dispatch_path = os.path.join(
         os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
@@ -70,6 +131,7 @@ def normalize_master_dispatch_artifact_callback(*_args, **_kwargs) -> None:
         return
 
     lane_counters: dict[str, int] = {}
+    issues = load_issue_bindings()
     active_nodes: list[str] = []
     for item in work_items:
         if not isinstance(item, dict):
@@ -77,16 +139,73 @@ def normalize_master_dispatch_artifact_callback(*_args, **_kwargs) -> None:
         node = str(item.get("node", "")).strip()
         if not node:
             continue
-        if node not in active_nodes:
+        logical_node_id = str(item.get("logical_node_id", "")).strip()
+        if logical_node_id and logical_node_id not in active_nodes:
+            active_nodes.append(logical_node_id)
+        elif node not in active_nodes:
             active_nodes.append(node)
-        worker_lane = str(item.get("worker_lane", "")).strip()
-        if not worker_lane:
-            lane_counters[node] = lane_counters.get(node, 0) + 1
-            lane_index = ((lane_counters[node] - 1) % pool_size_for_node(node)) + 1
-            worker_lane = lane_name_for_node(node, lane_index)
-            item["worker_lane"] = worker_lane
-        if not str(item.get("logical_node_id", "")).strip():
-            item["logical_node_id"] = worker_lane
+
+        lane_counters[node] = lane_counters.get(node, 0) + 1
+        lane_index = ((lane_counters[node] - 1) % pool_size_for_node(node)) + 1
+        worker_lane = normalize_worker_lane_name(
+            node,
+            logical_node_id,
+            str(item.get("worker_lane", "")),
+            lane_index,
+        )
+        item["worker_lane"] = worker_lane
+        if not logical_node_id:
+            logical_node_id = worker_lane
+            item["logical_node_id"] = logical_node_id
+
+        matched_issue = None
+        for issue in issues:
+            issue_number = str(issue.get("number", "")).strip()
+            if issue_number and issue_number == str(
+                item.get("github_issue_number") or item.get("issue_id") or ""
+            ).strip():
+                matched_issue = issue
+                break
+            if logical_node_id and logical_node_id == str(
+                issue.get("logical_node_id", "")
+            ).strip():
+                matched_issue = issue
+                break
+            if str(item.get("work_item_id", "")).strip() and str(
+                item.get("work_item_id", "")
+            ).strip() == str(issue.get("work_item_id", "")).strip():
+                matched_issue = issue
+                break
+        if matched_issue:
+            issue_number = int(matched_issue.get("number", 0) or 0)
+            if issue_number:
+                item["github_issue_number"] = issue_number
+                item["issue_id"] = str(issue_number)
+            if not str(item.get("branch_name", "")).strip():
+                item["branch_name"] = str(matched_issue.get("branch_name", "")).strip()
+            if not str(item.get("pr_title", "")).strip():
+                item["pr_title"] = str(matched_issue.get("title", "")).strip()
+
+        branch_name = str(item.get("branch_name", "")).strip()
+        if not str(item.get("worktree_path", "")).strip():
+            item["worktree_path"] = default_worktree_path_for(
+                worker_lane,
+                str(item.get("work_item_id", "")).strip(),
+                logical_node_id,
+                branch_name,
+            )
+
+        must_use_tools = item.get("must_use_tools", [])
+        if not isinstance(must_use_tools, list):
+            must_use_tools = []
+        for tool_name in (
+            "git_prepare_node_workspace",
+            "git_commit_and_push",
+            "github_create_or_update_pr",
+        ):
+            if tool_name not in must_use_tools:
+                must_use_tools.append(tool_name)
+        item["must_use_tools"] = must_use_tools
 
     if active_nodes and not contract.get("active_nodes"):
         contract["active_nodes"] = active_nodes
@@ -129,7 +248,14 @@ class MultiDev:
 
         model_name = os.getenv("OPENAI_MODEL_NAME", "qwen-plus")
         base_url = os.getenv("OPENAI_API_BASE") or os.getenv("OPENAI_BASE_URL")
-        default_max_tokens = "1000" if self.run_mode() == "fast" else "2200"
+        if self.run_mode() == "fast":
+            default_max_tokens = (
+                "2200"
+                if self.direct_dispatch_enabled() and self.execution_mode() == "write"
+                else "1000"
+            )
+        else:
+            default_max_tokens = "2200"
         max_tokens = int(os.getenv("CREW_LLM_MAX_TOKENS", default_max_tokens))
 
         return LLM(
@@ -709,22 +835,41 @@ class MultiDev:
         master_intake_context: list[Task] = []
         if not self.bootstrap_fast_track_enabled() and not self.direct_dispatch_enabled():
             master_intake_context = [repo_analysis_task, module_boundary_task]
+        master_intake_suffix = ""
+        if self.direct_dispatch_enabled() and self.execution_mode() == "write":
+            master_intake_suffix = (
+                "当前为 `direct_dispatch + write`，不得停留在“证据不足，先不派发”。\n"
+                "- 你必须先真实调用工具补齐最小证据：至少探测根级、后端、前端、测试/验证四类路径；\n"
+                "- 若用户需求已经点名具体能力（例如 `/health`、Hero 文案、购物车按钮、smoke 测试），你应围绕这些能力去定位真实文件，而不是只输出未知项；\n"
+                "- 输出必须压缩：只保留本轮真实需要的证据、风险和可派发结论，不要展开长篇规划。"
+            )
         master_intake_task = self.configured_task(
             "master_intake_task",
             agent_instance=master_controller,
             context=master_intake_context,
             name="master_intake_task",
+            description_suffix=master_intake_suffix,
         )
 
         master_dispatch_context = [master_intake_task]
         if not self.bootstrap_fast_track_enabled() and not self.direct_dispatch_enabled():
             master_dispatch_context.extend([issue_drafting_task, workspace_plan_task])
+        master_dispatch_suffix = ""
+        if self.direct_dispatch_enabled() and self.execution_mode() == "write":
+            master_dispatch_suffix = (
+                "当前为 `direct_dispatch + write`，你的首要目标是生成可立即执行的最小真实派单，而不是继续做探测计划。\n"
+                "- 若 `master_intake` 已拿到真实文件证据，你必须直接派发真实写入 work item；\n"
+                "- 若 `github_enabled=true`，对每个实际派发的 work item 都必须先创建真实 GitHub issue，再把 `github_issue_number` 写入 `dispatch_contract`；\n"
+                "- 你的正文应保持简短，只保留：派单原则、精简分工表、必要风险；\n"
+                "- 输出末尾必须附带完整 `dispatch_contract` JSON 代码块，且不得省略 `worker_lane`、`branch_name`、`worktree_path`、`github_issue_number`。"
+            )
         master_dispatch_task = self.configured_task(
             "master_dispatch_task",
             agent_instance=master_controller,
             context=master_dispatch_context,
             name="master_dispatch_task",
             callback=normalize_master_dispatch_artifact_callback,
+            description_suffix=master_dispatch_suffix,
         )
 
         lane_specs = self.build_execution_lane_specs()

--- a/src/multi_dev/crew.py
+++ b/src/multi_dev/crew.py
@@ -75,7 +75,7 @@ def default_worktree_path_for(
         os.getenv("TARGET_REPOSITORY_ROOT", str(Path.cwd()))
     ).expanduser().resolve()
     target = (
-        Path(__file__).resolve().parents[3]
+        Path(__file__).resolve().parents[2]
         / "outputs"
         / "worktrees"
         / repo_workspace_slug(repo_root)
@@ -85,7 +85,7 @@ def default_worktree_path_for(
 
 
 def load_issue_bindings() -> list[dict[str, object]]:
-    path = Path(__file__).resolve().parents[3] / "outputs" / "github_state.json"
+    path = Path(__file__).resolve().parents[2] / "outputs" / "github_state.json"
     if not path.exists():
         return []
     try:
@@ -105,6 +105,19 @@ def normalize_worker_lane_name(
     lane_index: int,
 ) -> str:
     candidate = raw_worker_lane.strip()
+    if "__" in node_name:
+        if candidate in {"", node_name}:
+            return node_name
+        if candidate.startswith(f"{node_name}__"):
+            return node_name
+    if candidate in {"backend", "backend_1"}:
+        return lane_name_for_node("backend_node", 1)
+    if candidate in {"frontend", "frontend_1"}:
+        return lane_name_for_node("frontend_node", 1)
+    if candidate == "frontend_2":
+        return lane_name_for_node("frontend_node", 2)
+    if candidate in {"tester", "tester_1"}:
+        return lane_name_for_node("tester_node", 1)
     if candidate.startswith(f"{node_name}__") or candidate == node_name:
         return candidate
     if logical_node_id.startswith(f"{node_name}__"):
@@ -840,7 +853,9 @@ class MultiDev:
             master_intake_suffix = (
                 "当前为 `direct_dispatch + write`，不得停留在“证据不足，先不派发”。\n"
                 "- 你必须先真实调用工具补齐最小证据：至少探测根级、后端、前端、测试/验证四类路径；\n"
+                "- 对已有业务仓库，至少补齐这 4 类真实证据之一：`src/**/*.py`、`frontend/src/**/*`、`frontend/**/*`、`tests/**/*.py`；\n"
                 "- 若用户需求已经点名具体能力（例如 `/health`、Hero 文案、购物车按钮、smoke 测试），你应围绕这些能力去定位真实文件，而不是只输出未知项；\n"
+                "- 不得因为某个猜测路径不存在，就把它写成阻塞；若 `frontend/index.html` 不存在，但 `frontend/src/App.jsx` 存在，你应继续围绕真实文件收敛；\n"
                 "- 输出必须压缩：只保留本轮真实需要的证据、风险和可派发结论，不要展开长篇规划。"
             )
         master_intake_task = self.configured_task(
@@ -860,6 +875,7 @@ class MultiDev:
                 "当前为 `direct_dispatch + write`，你的首要目标是生成可立即执行的最小真实派单，而不是继续做探测计划。\n"
                 "- 若 `master_intake` 已拿到真实文件证据，你必须直接派发真实写入 work item；\n"
                 "- 若 `github_enabled=true`，对每个实际派发的 work item 都必须先创建真实 GitHub issue，再把 `github_issue_number` 写入 `dispatch_contract`；\n"
+                "- 对已有业务仓库，`targets` 应尽量收敛到真实现有文件；不得把猜测路径写进派单，也不得让 node 在现有仓库里凭空新建平行实现；\n"
                 "- 你的正文应保持简短，只保留：派单原则、精简分工表、必要风险；\n"
                 "- 输出末尾必须附带完整 `dispatch_contract` JSON 代码块，且不得省略 `worker_lane`、`branch_name`、`worktree_path`、`github_issue_number`。"
             )
@@ -902,8 +918,12 @@ class MultiDev:
                 f"- 你只处理 `dispatch_contract.work_items` 中 `node=\"{base_node_name}\"`，且 `worker_lane=\"{lane_node_name}\"` 的项；"
                 "若当前 contract 未显式给出 `worker_lane`，仅 `__1` lane 可兜底接单，其余 lane 必须输出 `skipped`。\n"
                 f"- 所有 Git/GitHub 工具调用里的 `node_name` 参数必须使用 `{lane_node_name}`。\n"
+                "- 在已有业务仓库场景下，若 `targets` 是目录或 glob，你必须先用 `list_repo_files` / `read_repo_file` 找到真实现有文件，再开始修改；"
+                "只有 master 明确批准的 `拟新增文件` 才能直接新建。\n"
+                "- 若 `dispatch_contract.work_items[*]` 提供了 `candidate_files`，你必须优先读取并修改这些文件；不得绕开它们另起平行实现。\n"
                 "- 每个 work item 必须独立走完整链路：准备 worktree、真实写入、commit/push、创建或更新 PR；"
-                "不得把多个 work item 混到同一条 branch、同一个 worktree 或同一个 PR 中。"
+                "不得把多个 work item 混到同一条 branch、同一个 worktree 或同一个 PR 中。\n"
+                "- 若本节点没有留下真实工具痕迹（至少一次 repo 读取，以及写入或明确 GitHub 链路动作），本轮结果将直接视为未执行。"
             )
             lane_task = self.configured_task(
                 task_key,

--- a/src/multi_dev/crew.py
+++ b/src/multi_dev/crew.py
@@ -1,8 +1,11 @@
+import json
 import os
+import re
 
 from crewai import Agent, Crew, LLM, Process, Task
 from crewai.agents.agent_builder.base_agent import BaseAgent
 from crewai.project import CrewBase, agent, crew, task
+from multi_dev.tools.runtime_registry import extract_json_block
 from multi_dev.tools import (
     ScaffoldThinCICDWorkflowsTool,
     GitBranchDiffSummaryTool,
@@ -22,6 +25,89 @@ from multi_dev.tools import (
     ReplaceRepoTextTool,
     WriteRepoFileTool,
 )
+
+
+def pool_size_for_node(base_node_name: str) -> int:
+    env_map = {
+        "backend_node": "CREW_BACKEND_POOL_SIZE",
+        "frontend_node": "CREW_FRONTEND_POOL_SIZE",
+        "tester_node": "CREW_TESTER_POOL_SIZE",
+    }
+    raw_value = os.getenv(env_map.get(base_node_name, ""), "").strip()
+    if not raw_value:
+        raw_value = os.getenv("CREW_NODE_POOL_SIZE", "").strip()
+    if not raw_value:
+        raw_value = "2"
+    try:
+        value = int(raw_value)
+    except ValueError:
+        value = 2
+    return max(1, min(value, 6))
+
+
+def lane_name_for_node(base_node_name: str, lane_index: int) -> str:
+    if pool_size_for_node(base_node_name) <= 1:
+        return base_node_name
+    return f"{base_node_name}__{lane_index}"
+
+
+def normalize_master_dispatch_artifact_callback(*_args, **_kwargs) -> None:
+    dispatch_path = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+        "outputs",
+        "master_dispatch.md",
+    )
+    if not os.path.exists(dispatch_path):
+        return
+
+    content = open(dispatch_path, encoding="utf-8", errors="ignore").read()
+    contract = extract_json_block(content)
+    if not isinstance(contract, dict):
+        return
+
+    work_items = contract.get("work_items", [])
+    if not isinstance(work_items, list):
+        return
+
+    lane_counters: dict[str, int] = {}
+    active_nodes: list[str] = []
+    for item in work_items:
+        if not isinstance(item, dict):
+            continue
+        node = str(item.get("node", "")).strip()
+        if not node:
+            continue
+        if node not in active_nodes:
+            active_nodes.append(node)
+        worker_lane = str(item.get("worker_lane", "")).strip()
+        if not worker_lane:
+            lane_counters[node] = lane_counters.get(node, 0) + 1
+            lane_index = ((lane_counters[node] - 1) % pool_size_for_node(node)) + 1
+            worker_lane = lane_name_for_node(node, lane_index)
+            item["worker_lane"] = worker_lane
+        if not str(item.get("logical_node_id", "")).strip():
+            item["logical_node_id"] = worker_lane
+
+    if active_nodes and not contract.get("active_nodes"):
+        contract["active_nodes"] = active_nodes
+    if "inactive_nodes" not in contract:
+        contract["inactive_nodes"] = [
+            node_name
+            for node_name in ("backend_node", "frontend_node", "tester_node")
+            if node_name not in active_nodes
+        ]
+    if not str(contract.get("user_interface", "")).strip():
+        contract["user_interface"] = "master_only"
+
+    replacement = "```json\n" + json.dumps(contract, ensure_ascii=False, indent=2) + "\n```"
+    pattern = r"```(?:json|JSON)\s*(\{.*?\})\s*```"
+    matches = list(re.finditer(pattern, content, flags=re.DOTALL))
+    if not matches:
+        return
+    last_match = matches[-1]
+    updated = content[: last_match.start()] + replacement + content[last_match.end() :]
+    with open(dispatch_path, "w", encoding="utf-8") as file_handle:
+        file_handle.write(updated)
 
 
 @CrewBase
@@ -88,6 +174,101 @@ class MultiDev:
             for item in raw_value.split(",")
             if item.strip()
         )
+
+    def node_pool_size(self, base_node_name: str) -> int:
+        return pool_size_for_node(base_node_name)
+
+    def parallel_node_execution_enabled(self) -> bool:
+        return any(
+            self.node_pool_size(base_node_name) > 1
+            for base_node_name in ("backend_node", "frontend_node", "tester_node")
+        )
+
+    def lane_node_name(self, base_node_name: str, lane_index: int) -> str:
+        return lane_name_for_node(base_node_name, lane_index)
+
+    def lane_output_path(self, base_node_name: str, lane_index: int) -> str:
+        lane_node_name = self.lane_node_name(base_node_name, lane_index)
+        if lane_node_name == base_node_name:
+            return f"outputs/{base_node_name}.md"
+        return f"outputs/node_lanes/{lane_node_name}.md"
+
+    def configured_task(
+        self,
+        task_key: str,
+        *,
+        agent_instance: Agent,
+        context: list[Task] | None = None,
+        output_file: str | None = None,
+        name: str | None = None,
+        async_execution: bool = False,
+        description_suffix: str = "",
+        callback=None,
+    ) -> Task:
+        config = dict(self.tasks_config[task_key])  # type: ignore[index]
+        if description_suffix:
+            description = str(config.get("description", "")).rstrip()
+            config["description"] = f"{description}\n\n{description_suffix}".strip()
+        if output_file:
+            config["output_file"] = output_file
+        return Task(
+            name=name,
+            config=config,
+            agent=agent_instance,
+            context=context or [],
+            markdown=True,
+            async_execution=async_execution,
+            callback=callback,
+        )
+
+    def build_execution_agent(
+        self,
+        *,
+        config_key: str,
+        base_node_name: str,
+        lane_index: int,
+        allowed_prefixes: tuple[str, ...],
+    ) -> Agent:
+        lane_node_name = self.lane_node_name(base_node_name, lane_index)
+        config = dict(self.agents_config[config_key])  # type: ignore[index]
+        role = str(config.get("role", "")).strip()
+        if lane_node_name != base_node_name:
+            config["role"] = f"{role}（{lane_node_name}）"
+        return Agent(
+            config=config,
+            llm=self.shared_llm(),
+            tools=self.execution_tools(
+                allowed_prefixes=allowed_prefixes,
+                node_name=lane_node_name,
+            ),
+            verbose=True,
+            allow_delegation=False,
+        )
+
+    def build_execution_lane_specs(self) -> list[dict[str, object]]:
+        specs: list[dict[str, object]] = []
+        node_definitions = [
+            ("backend_node", "backend_node", "backend_node_task", "CREW_BACKEND_PATHS"),
+            ("frontend_node", "frontend_node", "frontend_node_task", "CREW_FRONTEND_PATHS"),
+            ("tester_node", "tester_node", "tester_node_task", "CREW_TEST_PATHS"),
+        ]
+        for base_node_name, config_key, task_key, env_name in node_definitions:
+            allowed_prefixes = self.node_allowed_prefixes(env_name)
+            pool_size = self.node_pool_size(base_node_name)
+            for lane_index in range(1, pool_size + 1):
+                lane_node_name = self.lane_node_name(base_node_name, lane_index)
+                specs.append(
+                    {
+                        "base_node_name": base_node_name,
+                        "config_key": config_key,
+                        "task_key": task_key,
+                        "lane_index": lane_index,
+                        "lane_node_name": lane_node_name,
+                        "output_file": self.lane_output_path(base_node_name, lane_index),
+                        "allowed_prefixes": allowed_prefixes,
+                    }
+                )
+        return specs
 
     def read_tools(
         self,
@@ -491,21 +672,208 @@ class MultiDev:
         run_mode = self.run_mode()
         process = Process.sequential if run_mode == "fast" else Process.hierarchical
         manager_agent = None if run_mode == "fast" else self.master_manager()
-        tasks = self.tasks
+
+        master_controller = self.master_controller()
+        repo_analyst = self.repo_analyst()
+        task_planner = self.task_planner()
+        issue_writer = self.issue_writer()
+        developer_worker = self.developer_worker()
+        reviewer_worker = self.reviewer_worker()
+
+        repo_analysis_task = self.configured_task(
+            "repo_analysis_task",
+            agent_instance=repo_analyst,
+            name="repo_analysis_task",
+        )
+        module_boundary_task = self.configured_task(
+            "module_boundary_task",
+            agent_instance=task_planner,
+            context=[repo_analysis_task],
+            name="module_boundary_task",
+        )
+        issue_drafting_task = self.configured_task(
+            "issue_drafting_task",
+            agent_instance=issue_writer,
+            context=[repo_analysis_task, module_boundary_task],
+            name="issue_drafting_task",
+        )
+        workspace_plan_task = self.configured_task(
+            "workspace_plan_task",
+            agent_instance=task_planner,
+            context=[repo_analysis_task, module_boundary_task, issue_drafting_task],
+            name="workspace_plan_task",
+        )
+
+        master_intake_context: list[Task] = []
+        if not self.bootstrap_fast_track_enabled():
+            master_intake_context = [repo_analysis_task, module_boundary_task]
+        master_intake_task = self.configured_task(
+            "master_intake_task",
+            agent_instance=master_controller,
+            context=master_intake_context,
+            name="master_intake_task",
+        )
+
+        master_dispatch_context = [master_intake_task]
+        if not self.bootstrap_fast_track_enabled():
+            master_dispatch_context.extend([issue_drafting_task, workspace_plan_task])
+        master_dispatch_task = self.configured_task(
+            "master_dispatch_task",
+            agent_instance=master_controller,
+            context=master_dispatch_context,
+            name="master_dispatch_task",
+            callback=normalize_master_dispatch_artifact_callback,
+        )
+
+        lane_specs = self.build_execution_lane_specs()
+        execution_lane_agents: list[Agent] = []
+        backend_tasks: list[Task] = []
+        frontend_tasks: list[Task] = []
+        tester_tasks: list[Task] = []
+        async_lanes = self.parallel_node_execution_enabled()
+
+        for spec in lane_specs:
+            base_node_name = str(spec["base_node_name"])
+            lane_index = int(spec["lane_index"])
+            lane_node_name = str(spec["lane_node_name"])
+            task_key = str(spec["task_key"])
+            config_key = str(spec["config_key"])
+            output_file = str(spec["output_file"])
+            allowed_prefixes = tuple(spec["allowed_prefixes"])
+            lane_agent = self.build_execution_agent(
+                config_key=config_key,
+                base_node_name=base_node_name,
+                lane_index=lane_index,
+                allowed_prefixes=allowed_prefixes,
+            )
+            execution_lane_agents.append(lane_agent)
+            context = [master_dispatch_task]
+            if base_node_name == "tester_node" and not self.bootstrap_fast_track_enabled():
+                context = [master_dispatch_task, *backend_tasks, *frontend_tasks]
+            lane_description = (
+                f"当前执行 lane 标识：`{lane_node_name}`。\n"
+                f"- 你只处理 `dispatch_contract.work_items` 中 `node=\"{base_node_name}\"`，且 `worker_lane=\"{lane_node_name}\"` 的项；"
+                "若当前 contract 未显式给出 `worker_lane`，仅 `__1` lane 可兜底接单，其余 lane 必须输出 `skipped`。\n"
+                f"- 所有 Git/GitHub 工具调用里的 `node_name` 参数必须使用 `{lane_node_name}`。\n"
+                "- 每个 work item 必须独立走完整链路：准备 worktree、真实写入、commit/push、创建或更新 PR；"
+                "不得把多个 work item 混到同一条 branch、同一个 worktree 或同一个 PR 中。"
+            )
+            lane_task = self.configured_task(
+                task_key,
+                agent_instance=lane_agent,
+                context=context,
+                output_file=output_file,
+                name=f"{lane_node_name}_task",
+                async_execution=(
+                    async_lanes
+                    and (
+                        base_node_name in {"backend_node", "frontend_node"}
+                        or self.bootstrap_fast_track_enabled()
+                    )
+                ),
+                description_suffix=lane_description,
+            )
+            if base_node_name == "backend_node":
+                backend_tasks.append(lane_task)
+            elif base_node_name == "frontend_node":
+                frontend_tasks.append(lane_task)
+            else:
+                tester_tasks.append(lane_task)
+
+        node_execution_tasks = [*backend_tasks, *frontend_tasks, *tester_tasks]
+
+        pr_drafting_task = self.configured_task(
+            "pr_drafting_task",
+            agent_instance=developer_worker,
+            context=[master_dispatch_task, *node_execution_tasks],
+            name="pr_drafting_task",
+        )
+        execution_summary_task = self.configured_task(
+            "execution_summary_task",
+            agent_instance=developer_worker,
+            context=node_execution_tasks,
+            name="execution_summary_task",
+        )
+        github_automation_task = self.configured_task(
+            "github_automation_task",
+            agent_instance=developer_worker,
+            context=[
+                master_dispatch_task,
+                *node_execution_tasks,
+                pr_drafting_task,
+                execution_summary_task,
+            ],
+            name="github_automation_task",
+        )
+
+        reviewer_context = [
+            master_intake_task,
+            master_dispatch_task,
+            *node_execution_tasks,
+            execution_summary_task,
+        ]
+        if not self.bootstrap_fast_track_enabled():
+            reviewer_context.extend([pr_drafting_task, github_automation_task])
+        reviewer_audit_task = self.configured_task(
+            "reviewer_audit_task",
+            agent_instance=reviewer_worker,
+            context=reviewer_context,
+            name="reviewer_audit_task",
+        )
+
+        master_decision_context = [
+            master_intake_task,
+            master_dispatch_task,
+            *node_execution_tasks,
+            execution_summary_task,
+            reviewer_audit_task,
+        ]
+        if not self.bootstrap_fast_track_enabled():
+            master_decision_context.extend([pr_drafting_task, github_automation_task])
+        master_decision_task = self.configured_task(
+            "master_decision_task",
+            agent_instance=master_controller,
+            context=master_decision_context,
+            name="master_decision_task",
+        )
+
         if self.bootstrap_fast_track_enabled():
             tasks = [
-                self.master_intake_task(),
-                self.master_dispatch_task(),
-                self.backend_node_task(),
-                self.frontend_node_task(),
-                self.tester_node_task(),
-                self.execution_summary_task(),
-                self.reviewer_audit_task(),
-                self.master_decision_task(),
+                master_intake_task,
+                master_dispatch_task,
+                *node_execution_tasks,
+                execution_summary_task,
+                reviewer_audit_task,
+                master_decision_task,
+            ]
+        else:
+            tasks = [
+                repo_analysis_task,
+                module_boundary_task,
+                issue_drafting_task,
+                workspace_plan_task,
+                master_intake_task,
+                master_dispatch_task,
+                *node_execution_tasks,
+                pr_drafting_task,
+                execution_summary_task,
+                github_automation_task,
+                reviewer_audit_task,
+                master_decision_task,
             ]
 
+        agents = [
+            master_controller,
+            repo_analyst,
+            task_planner,
+            issue_writer,
+            developer_worker,
+            reviewer_worker,
+            *execution_lane_agents,
+        ]
+
         return Crew(
-            agents=self.agents,
+            agents=agents,
             tasks=tasks,
             process=process,
             manager_agent=manager_agent,

--- a/src/multi_dev/main.py
+++ b/src/multi_dev/main.py
@@ -14,6 +14,10 @@ from pathlib import Path
 from multi_dev.crew import MultiDev
 from multi_dev.services import sync_dispatch_runtime_state
 from multi_dev.tools.runtime_registry import base_node_name
+from multi_dev.tools.git_github_tools import (
+    GitHubMergePRTool,
+    GitHubReviewPRTool,
+)
 
 warnings.filterwarnings("ignore", category=SyntaxWarning, module="pysbd")
 
@@ -550,6 +554,17 @@ def execution_log_entries() -> list[dict[str, object]]:
         if isinstance(parsed, dict):
             entries.append(parsed)
     return entries
+
+
+def github_state_or_none() -> dict[str, object] | None:
+    path = output_path("outputs/github_state.json")
+    if not path.exists():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8", errors="ignore"))
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, dict) else None
 
 
 def dispatch_contract_or_none() -> dict[str, object] | None:
@@ -1145,6 +1160,157 @@ def build_round_summary(
     return json.dumps(summary, ensure_ascii=False)
 
 
+def review_body_for_pr(
+    *,
+    decision: str,
+    pr_payload: dict[str, object],
+    reviewer_contract: dict[str, object] | None,
+    decision_contract: dict[str, object],
+) -> str:
+    node_name = str(pr_payload.get("node", "")).strip()
+    logical_node_id = str(pr_payload.get("logical_node_id", "")).strip()
+    work_item_id = str(pr_payload.get("work_item_id", "")).strip()
+    stop_reason = str(decision_contract.get("stop_reason", "")).strip()
+    rework_items = reviewer_contract.get("rework_items", []) if reviewer_contract else []
+    if not isinstance(rework_items, list):
+        rework_items = []
+    related_items = [
+        str(item).strip()
+        for item in rework_items
+        if str(item).strip()
+        and (
+            node_name in str(item)
+            or logical_node_id in str(item)
+            or work_item_id in str(item)
+        )
+    ]
+
+    if decision == "REWORK":
+        lines = [
+            "master 已审阅本 PR，本轮结论为 `REQUEST_CHANGES`。",
+            "",
+            "需要修复后再提交：",
+        ]
+        if related_items:
+            lines.extend(f"- {item}" for item in related_items)
+        elif stop_reason:
+            lines.append(f"- {stop_reason}")
+        else:
+            lines.append("- 本 PR 未满足本轮调度单与 reviewer 审计要求。")
+        return "\n".join(lines)
+
+    if decision == "CONTINUE_DISPATCH":
+        lines = [
+            "master 已审阅本 PR，本轮暂不合并，保留为后续继续派发的输入。",
+        ]
+        if stop_reason:
+            lines.extend(["", f"- 当前阶段说明：{stop_reason}"])
+        return "\n".join(lines)
+
+    return "master 已审阅本 PR，允许进入合并阶段。"
+
+
+def should_skip_review(
+    *,
+    reviews: list[dict[str, object]],
+    pr_number: int,
+    event: str,
+) -> bool:
+    for review in reviews:
+        if not isinstance(review, dict):
+            continue
+        if int(review.get("pull_request_number", 0) or 0) != pr_number:
+            continue
+        if str(review.get("event", "")).upper() == event:
+            return True
+    return False
+
+
+def apply_github_decision_actions(
+    *,
+    inputs: dict[str, str],
+    decision_contract: dict[str, object],
+    reviewer_contract: dict[str, object] | None,
+) -> None:
+    if inputs.get("github_enabled") != "true":
+        return
+
+    state = github_state_or_none()
+    if not state:
+        return
+
+    pull_requests = state.get("pull_requests", [])
+    if not isinstance(pull_requests, list) or not pull_requests:
+        return
+
+    decision = str(decision_contract.get("decision", "")).upper()
+    rerun_nodes = decision_contract.get("rerun_nodes", [])
+    if not isinstance(rerun_nodes, list):
+        rerun_nodes = []
+    rerun_nodes = [str(node).strip() for node in rerun_nodes if str(node).strip()]
+
+    failed_nodes = reviewer_contract.get("failed_nodes", []) if reviewer_contract else []
+    if not isinstance(failed_nodes, list):
+        failed_nodes = []
+    failed_nodes = [str(node).strip() for node in failed_nodes if str(node).strip()]
+
+    if decision == "REWORK":
+        target_nodes = set(rerun_nodes or failed_nodes)
+        event = "REQUEST_CHANGES"
+    elif decision == "CONTINUE_DISPATCH":
+        target_nodes = set(rerun_nodes or failed_nodes)
+        event = "COMMENT"
+    elif decision == "MERGE":
+        target_nodes = set()
+        event = "APPROVE"
+    else:
+        return
+
+    reviews = state.get("pull_request_reviews", [])
+    if not isinstance(reviews, list):
+        reviews = []
+
+    review_tool = GitHubReviewPRTool()
+    merge_tool = GitHubMergePRTool()
+
+    for pr in pull_requests:
+        if not isinstance(pr, dict):
+            continue
+        pr_number = int(pr.get("number", 0) or 0)
+        if not pr_number:
+            continue
+        node_name = base_node_name(str(pr.get("node", "")).strip())
+        if decision in {"REWORK", "CONTINUE_DISPATCH"} and target_nodes and node_name not in target_nodes:
+            continue
+        if decision == "MERGE" and failed_nodes and node_name in set(failed_nodes):
+            continue
+        if should_skip_review(reviews=reviews, pr_number=pr_number, event=event):
+            continue
+
+        body = review_body_for_pr(
+            decision=decision,
+            pr_payload=pr,
+            reviewer_contract=reviewer_contract,
+            decision_contract=decision_contract,
+        )
+        review_event = event
+        try:
+            review_tool._run(pr_number=pr_number, event=review_event, body=body)
+        except Exception as exc:
+            fallback_body = body
+            if review_event != "COMMENT":
+                fallback_body = (
+                    f"{body}\n\n"
+                    f"> 注：原计划执行 `{review_event}`，但当前 GitHub 身份/权限返回错误：{exc}。"
+                    " 已自动降级为 `COMMENT` 留痕。"
+                )
+            review_event = "COMMENT"
+            review_tool._run(pr_number=pr_number, event=review_event, body=fallback_body)
+
+        if decision == "MERGE":
+            merge_tool._run(pr_number=pr_number, merge_method="squash", delete_branch=False)
+
+
 def kickoff_round(inputs: dict[str, str]) -> None:
     MultiDev().crew().kickoff(inputs=inputs)
 
@@ -1176,6 +1342,11 @@ def run_round_loop(base_inputs: dict[str, str]) -> None:
             reviewer_contract=reviewer_contract,
             decision_contract=decision_contract,
             execution_entries=execution_log_entries(),
+        )
+        apply_github_decision_actions(
+            inputs=current_inputs,
+            decision_contract=decision_contract,
+            reviewer_contract=reviewer_contract,
         )
         archive_round_artifacts(round_index)
 

--- a/src/multi_dev/main.py
+++ b/src/multi_dev/main.py
@@ -12,6 +12,8 @@ from datetime import datetime
 from pathlib import Path
 
 from multi_dev.crew import MultiDev
+from multi_dev.services import sync_dispatch_runtime_state
+from multi_dev.tools.runtime_registry import base_node_name
 
 warnings.filterwarnings("ignore", category=SyntaxWarning, module="pysbd")
 
@@ -121,6 +123,10 @@ ARTIFACT_PATHS = [
     "outputs/execution_log.jsonl",
     "outputs/github_state.json",
     "outputs/node_workspaces.json",
+    "outputs/dispatch_rounds.json",
+    "outputs/work_items.json",
+    "outputs/pr_bindings.json",
+    "outputs/ownership_rules.json",
     "outputs/github_automation.md",
     "outputs/reviewer_audit.md",
     "outputs/master_decision.md",
@@ -179,6 +185,9 @@ def clean_previous_artifacts() -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
         if path.exists():
             path.unlink()
+    lane_root = outputs_root() / "node_lanes"
+    if lane_root.exists():
+        shutil.rmtree(lane_root)
     if rounds_root().exists():
         shutil.rmtree(rounds_root())
         rounds_root().mkdir(parents=True, exist_ok=True)
@@ -516,6 +525,13 @@ def archive_round_artifacts(round_index: int) -> None:
     for path in artifact_paths():
         if path.exists():
             shutil.copy2(path, round_dir / path.name)
+    lane_root = outputs_root() / "node_lanes"
+    if lane_root.exists():
+        shutil.copytree(
+            lane_root,
+            round_dir / "node_lanes",
+            dirs_exist_ok=True,
+        )
 
 
 def execution_log_entries() -> list[dict[str, object]]:
@@ -572,7 +588,7 @@ def nodes_with_real_writes(entries: list[dict[str, object]]) -> set[str]:
         details = entry.get("details", {})
         if not isinstance(details, dict):
             continue
-        node = str(details.get("node", "")).strip()
+        node = base_node_name(str(details.get("node", "")).strip())
         if node:
             nodes.add(node)
     return nodes
@@ -620,11 +636,33 @@ def write_entries_by_node(
         details = entry.get("details", {})
         if not isinstance(details, dict):
             continue
-        node = str(details.get("node", "")).strip()
+        node = base_node_name(str(details.get("node", "")).strip())
         if not node:
             continue
         grouped.setdefault(node, []).append(entry)
     return grouped
+
+
+def aggregate_node_lane_outputs() -> None:
+    outputs = outputs_root()
+    lane_root = outputs / "node_lanes"
+    if not lane_root.exists():
+        return
+
+    for base_node in ("backend_node", "frontend_node", "tester_node"):
+        segments: list[str] = []
+        for lane_file in sorted(lane_root.glob(f"{base_node}*.md")):
+            body = lane_file.read_text(encoding="utf-8", errors="ignore").strip()
+            if not body:
+                continue
+            segments.append(f"## {lane_file.stem}\n\n{body}")
+
+        target_path = outputs / f"{base_node}.md"
+        if segments:
+            target_path.write_text(
+                "# 聚合节点输出\n\n" + "\n\n".join(segments) + "\n",
+                encoding="utf-8",
+            )
 
 
 def path_authorized_for_targets(
@@ -1118,13 +1156,12 @@ def run_round_loop(base_inputs: dict[str, str]) -> None:
         current_inputs["round_index"] = str(round_index)
         print(f"\n===== Round {round_index}/{max_rounds()} =====")
         kickoff_round(current_inputs)
+        aggregate_node_lane_outputs()
         enforce_bootstrap_write_progress(round_index=round_index, inputs=current_inputs)
         stabilize_bootstrap_fast_track_outputs(
             round_index=round_index,
             inputs=current_inputs,
         )
-        archive_round_artifacts(round_index)
-
         decision_contract = load_json_contract(output_path("outputs/master_decision.md"))
         reviewer_contract: dict[str, object] | None = None
         reviewer_path = output_path("outputs/reviewer_audit.md")
@@ -1132,6 +1169,15 @@ def run_round_loop(base_inputs: dict[str, str]) -> None:
             reviewer_contract = extract_json_block(
                 reviewer_path.read_text(encoding="utf-8", errors="ignore")
             )
+        sync_dispatch_runtime_state(
+            round_index=round_index,
+            inputs=current_inputs,
+            dispatch_contract=dispatch_contract_or_none(),
+            reviewer_contract=reviewer_contract,
+            decision_contract=decision_contract,
+            execution_entries=execution_log_entries(),
+        )
+        archive_round_artifacts(round_index)
 
         decision = str(decision_contract.get("decision", "")).upper()
         rerun_nodes = decision_contract.get("rerun_nodes", [])

--- a/src/multi_dev/models/__init__.py
+++ b/src/multi_dev/models/__init__.py
@@ -1,0 +1,3 @@
+from multi_dev.models.dispatch import DispatchRoundRecord, WorkItemRecord
+
+__all__ = ["DispatchRoundRecord", "WorkItemRecord"]

--- a/src/multi_dev/models/dispatch.py
+++ b/src/multi_dev/models/dispatch.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(slots=True)
+class DispatchRoundRecord:
+    round_index: int
+    mode: str
+    execution_mode: str
+    bootstrap_mode: str
+    bootstrap_fast_track: bool
+    user_interface: str
+    active_nodes: list[str] = field(default_factory=list)
+    active_logical_nodes: list[str] = field(default_factory=list)
+    inactive_nodes: list[str] = field(default_factory=list)
+    work_item_ids: list[str] = field(default_factory=list)
+    retry_nodes: list[str] = field(default_factory=list)
+    retry_reason: str = ""
+    previous_round_summary: str = ""
+    reviewer_verdict: str = ""
+    decision: str = ""
+    rerun_nodes: list[str] = field(default_factory=list)
+    stop_reason: str = ""
+    real_write_nodes: list[str] = field(default_factory=list)
+    real_write_count: int = 0
+    updated_at: str = ""
+
+
+@dataclass(slots=True)
+class WorkItemRecord:
+    work_item_id: str
+    round_index: int
+    state: str
+    node: str
+    action: str
+    issue_id: str
+    logical_node_id: str = ""
+    worker_lane: str = ""
+    depends_on: list[str] = field(default_factory=list)
+    github_issue_number: int = 0
+    pr_number: int = 0
+    pr_status: str = ""
+    issue_status: str = ""
+    branch_name: str = ""
+    worktree_path: str = ""
+    pr_title: str = ""
+    targets: list[str] = field(default_factory=list)
+    must_use_tools: list[str] = field(default_factory=list)
+    done_when: list[str] = field(default_factory=list)
+    write_paths: list[str] = field(default_factory=list)
+    write_count: int = 0
+    last_round_index: int = 0
+    attempt_count: int = 1
+    updated_at: str = ""

--- a/src/multi_dev/services/__init__.py
+++ b/src/multi_dev/services/__init__.py
@@ -1,0 +1,3 @@
+from multi_dev.services.dispatch_state import sync_dispatch_runtime_state
+
+__all__ = ["sync_dispatch_runtime_state"]

--- a/src/multi_dev/services/dispatch_state.py
+++ b/src/multi_dev/services/dispatch_state.py
@@ -1,0 +1,498 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from multi_dev.models.dispatch import DispatchRoundRecord, WorkItemRecord
+from multi_dev.tools.runtime_registry import load_workspace_registry, workspace_binding_for
+
+
+def project_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def outputs_root() -> Path:
+    path = project_root() / "outputs"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def dispatch_rounds_path() -> Path:
+    return outputs_root() / "dispatch_rounds.json"
+
+
+def work_items_path() -> Path:
+    return outputs_root() / "work_items.json"
+
+
+def pr_bindings_path() -> Path:
+    return outputs_root() / "pr_bindings.json"
+
+
+def ownership_rules_path() -> Path:
+    return outputs_root() / "ownership_rules.json"
+
+
+def github_state_path() -> Path:
+    return outputs_root() / "github_state.json"
+
+
+def node_workspaces_path() -> Path:
+    return outputs_root() / "node_workspaces.json"
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def load_json_file(path: Path, default: Any) -> Any:
+    if not path.exists():
+        return default
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return default
+
+
+def save_json_file(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+
+def load_github_state() -> dict[str, Any]:
+    return load_json_file(
+        github_state_path(),
+        {"repo": {}, "issues": [], "pull_requests": [], "node_workspaces": {}},
+    )
+
+
+def load_node_workspaces() -> dict[str, Any]:
+    return load_workspace_registry()
+
+
+def list_of_strings(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item).strip() for item in value if str(item).strip()]
+
+
+def as_int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def active_work_items(contract: dict[str, Any] | None) -> list[dict[str, Any]]:
+    if not isinstance(contract, dict):
+        return []
+    work_items = contract.get("work_items", [])
+    if not isinstance(work_items, list):
+        return []
+
+    active_nodes = set(list_of_strings(contract.get("active_nodes", [])))
+    if not active_nodes:
+        active_nodes = {
+            str(item.get("node", "")).strip()
+            for item in work_items
+            if isinstance(item, dict) and str(item.get("node", "")).strip()
+        }
+
+    active_items: list[dict[str, Any]] = []
+    for item in work_items:
+        if not isinstance(item, dict):
+            continue
+        node = str(item.get("node", "")).strip()
+        action = str(item.get("action", "")).strip().lower()
+        if not node or node not in active_nodes:
+            continue
+        if action in {"skip", "skipped", "inactive", "not_dispatched"}:
+            continue
+        active_items.append(item)
+    return active_items
+
+
+def write_entries_by_node(
+    execution_entries: list[dict[str, Any]],
+) -> dict[str, list[dict[str, Any]]]:
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for entry in execution_entries:
+        if str(entry.get("action", "")).strip() not in {"mkdir", "write_file", "replace_text"}:
+            continue
+        details = entry.get("details", {})
+        if not isinstance(details, dict):
+            continue
+        node = str(details.get("node", "")).strip()
+        if not node:
+            continue
+        grouped.setdefault(node, []).append(entry)
+    return grouped
+
+
+def write_entries_for_work_item(
+    execution_entries: list[dict[str, Any]],
+    *,
+    node: str,
+    work_item_id: str = "",
+) -> list[dict[str, Any]]:
+    if work_item_id:
+        scoped: list[dict[str, Any]] = []
+        for entry in execution_entries:
+            details = entry.get("details", {})
+            if not isinstance(details, dict):
+                continue
+            if str(details.get("node", "")).strip() != node:
+                continue
+            if str(details.get("work_item_id", "")).strip() != work_item_id:
+                continue
+            scoped.append(entry)
+        if scoped:
+            return scoped
+
+    return write_entries_by_node(execution_entries).get(node, [])
+
+
+def find_issue(
+    github_state: dict[str, Any],
+    issue_id: str,
+    work_item_id: str,
+    issue_number: int,
+    node: str,
+    branch_name: str,
+) -> dict[str, Any] | None:
+    issues = github_state.get("issues", [])
+    if not isinstance(issues, list):
+        return None
+
+    for issue in issues:
+        if not isinstance(issue, dict):
+            continue
+        if issue_number and as_int(issue.get("number")) == issue_number:
+            return issue
+        if work_item_id and str(issue.get("work_item_id", "")).strip() == work_item_id:
+            return issue
+        if issue_id and str(issue.get("issue_key", "")).strip() == issue_id:
+            return issue
+        if branch_name and str(issue.get("branch_name", "")).strip() == branch_name:
+            return issue
+        if node and str(issue.get("node", "")).strip() == node:
+            return issue
+    return None
+
+
+def find_pr(
+    github_state: dict[str, Any],
+    work_item_id: str,
+    issue_number: int,
+    node: str,
+    branch_name: str,
+) -> dict[str, Any] | None:
+    pull_requests = github_state.get("pull_requests", [])
+    if not isinstance(pull_requests, list):
+        return None
+
+    for pr in pull_requests:
+        if not isinstance(pr, dict):
+            continue
+        if issue_number and as_int(pr.get("issue_number")) == issue_number:
+            return pr
+        if work_item_id and str(pr.get("work_item_id", "")).strip() == work_item_id:
+            return pr
+        if branch_name and str(pr.get("head_branch", "")).strip() == branch_name:
+            return pr
+        if node and str(pr.get("node", "")).strip() == node:
+            return pr
+    return None
+
+
+def infer_work_item_state(
+    decision: str,
+    reviewer_verdict: str,
+    rerun_nodes: list[str],
+    failed_nodes: list[str],
+    pr_status: str,
+    has_writes: bool,
+) -> str:
+    normalized_pr_status = pr_status.strip().lower()
+    if normalized_pr_status == "merged":
+        return "MERGED"
+    if decision == "MERGE" and has_writes:
+        return "MERGED"
+    if decision == "REWORK" and (rerun_nodes or failed_nodes):
+        return "REWORK_REQUIRED"
+    if reviewer_verdict == "REWORK" and failed_nodes:
+        return "REWORK_REQUIRED"
+    if normalized_pr_status in {"open", "in_review"}:
+        return "IN_REVIEW"
+    if has_writes:
+        return "IN_PROGRESS"
+    return "DISPATCHED"
+
+
+def build_work_item_record(
+    item: dict[str, Any],
+    round_index: int,
+    decision_contract: dict[str, Any] | None,
+    reviewer_contract: dict[str, Any] | None,
+    execution_entries: list[dict[str, Any]],
+    github_state: dict[str, Any],
+    node_workspaces: dict[str, Any],
+) -> WorkItemRecord:
+    node = str(item.get("node", "")).strip()
+    work_item_id = str(item.get("work_item_id") or item.get("issue_id") or "").strip()
+    issue_id = str(item.get("issue_id", "")).strip() or work_item_id or f"round-{round_index}-{node}"
+    logical_node_id = str(item.get("logical_node_id", "")).strip()
+    worker_lane = str(item.get("worker_lane", "")).strip()
+    branch_name = str(item.get("branch_name", "")).strip()
+    github_issue_number = as_int(item.get("github_issue_number"))
+    targets = list_of_strings(item.get("targets", []))
+    must_use_tools = list_of_strings(item.get("must_use_tools", []))
+    done_when = list_of_strings(item.get("done_when", []))
+    depends_on = list_of_strings(item.get("depends_on", []))
+
+    workspace = workspace_binding_for(node_name=node, work_item_id=work_item_id)
+    if not workspace and isinstance(node_workspaces, dict):
+        by_node = node_workspaces.get("by_node", {})
+        if isinstance(by_node, dict):
+            workspace = by_node.get(node, {})
+    if not isinstance(workspace, dict):
+        workspace = {}
+
+    linked_issue = find_issue(
+        github_state=github_state,
+        issue_id=issue_id,
+        work_item_id=work_item_id,
+        issue_number=github_issue_number,
+        node=node,
+        branch_name=branch_name,
+    )
+    if linked_issue:
+        github_issue_number = github_issue_number or as_int(linked_issue.get("number"))
+
+    linked_pr = find_pr(
+        github_state=github_state,
+        work_item_id=work_item_id,
+        issue_number=github_issue_number,
+        node=node,
+        branch_name=branch_name,
+    )
+
+    node_entries = write_entries_for_work_item(
+        execution_entries,
+        node=node,
+        work_item_id=work_item_id,
+    )
+    write_paths = [
+        str(entry.get("path", "")).strip()
+        for entry in node_entries
+        if str(entry.get("path", "")).strip()
+    ]
+    decision = str((decision_contract or {}).get("decision", "")).upper()
+    reviewer_verdict = str((reviewer_contract or {}).get("verdict", "")).upper()
+    rerun_nodes = list_of_strings((decision_contract or {}).get("rerun_nodes", []))
+    failed_nodes = list_of_strings((reviewer_contract or {}).get("failed_nodes", []))
+    state = infer_work_item_state(
+        decision=decision,
+        reviewer_verdict=reviewer_verdict,
+        rerun_nodes=rerun_nodes if node in rerun_nodes else [],
+        failed_nodes=failed_nodes if node in failed_nodes else [],
+        pr_status=str((linked_pr or {}).get("status", "")).strip(),
+        has_writes=bool(write_paths),
+    )
+
+    return WorkItemRecord(
+        work_item_id=work_item_id or issue_id,
+        round_index=round_index,
+        last_round_index=round_index,
+        state=state,
+        node=node,
+        logical_node_id=logical_node_id,
+        worker_lane=worker_lane,
+        action=str(item.get("action", "")).strip(),
+        issue_id=issue_id,
+        depends_on=depends_on,
+        github_issue_number=github_issue_number,
+        pr_number=as_int((linked_pr or {}).get("number")),
+        pr_status=str((linked_pr or {}).get("status", "")).strip(),
+        issue_status=str((linked_issue or {}).get("status", "")).strip(),
+        branch_name=branch_name or str((linked_pr or {}).get("head_branch", "")).strip() or str(workspace.get("branch_name", "")).strip(),
+        worktree_path=str(item.get("worktree_path", "")).strip() or str(workspace.get("worktree_path", "")).strip(),
+        pr_title=str(item.get("pr_title", "")).strip() or str((linked_pr or {}).get("title", "")).strip(),
+        targets=targets,
+        must_use_tools=must_use_tools,
+        done_when=done_when,
+        write_paths=sorted(dict.fromkeys(write_paths)),
+        write_count=len(write_paths),
+        updated_at=now_iso(),
+    )
+
+
+def upsert_dispatch_rounds(records: list[DispatchRoundRecord]) -> None:
+    path = dispatch_rounds_path()
+    payload = load_json_file(path, {"rounds": []})
+    existing = payload.get("rounds", [])
+    if not isinstance(existing, list):
+        existing = []
+
+    indexed = {
+        as_int(record.get("round_index")): record
+        for record in existing
+        if isinstance(record, dict)
+    }
+    for record in records:
+        indexed[record.round_index] = asdict(record)
+
+    merged = [indexed[key] for key in sorted(indexed)]
+    save_json_file(path, {"rounds": merged})
+
+
+def upsert_work_items(records: list[WorkItemRecord]) -> None:
+    path = work_items_path()
+    payload = load_json_file(path, {"work_items": []})
+    existing = payload.get("work_items", [])
+    if not isinstance(existing, list):
+        existing = []
+
+    indexed = {
+        str(record.get("work_item_id", "")).strip(): record
+        for record in existing
+        if isinstance(record, dict) and str(record.get("work_item_id", "")).strip()
+    }
+
+    for record in records:
+        previous = indexed.get(record.work_item_id)
+        if isinstance(previous, dict):
+            previous_round = as_int(previous.get("last_round_index"))
+            attempt_count = as_int(previous.get("attempt_count")) or 1
+            record.attempt_count = (
+                attempt_count + 1 if previous_round and previous_round != record.round_index else attempt_count
+            )
+        indexed[record.work_item_id] = asdict(record)
+
+    merged = [
+        indexed[key]
+        for key in sorted(
+            indexed,
+            key=lambda item_id: (
+                as_int(indexed[item_id].get("last_round_index")),
+                item_id,
+            ),
+        )
+    ]
+    save_json_file(path, {"work_items": merged})
+
+
+def save_pr_bindings(records: list[WorkItemRecord]) -> None:
+    payload = {
+        "pr_bindings": [
+            {
+                "work_item_id": record.work_item_id,
+                "node": record.node,
+                "logical_node_id": record.logical_node_id,
+                "worker_lane": record.worker_lane,
+                "issue_id": record.issue_id,
+                "github_issue_number": record.github_issue_number,
+                "pr_number": record.pr_number,
+                "pr_status": record.pr_status,
+                "branch_name": record.branch_name,
+                "worktree_path": record.worktree_path,
+                "pr_title": record.pr_title,
+            }
+            for record in records
+        ]
+    }
+    save_json_file(pr_bindings_path(), payload)
+
+
+def save_ownership_rules(records: list[WorkItemRecord]) -> None:
+    payload = {
+        "ownership_rules": [
+            {
+                "work_item_id": record.work_item_id,
+                "node": record.node,
+                "logical_node_id": record.logical_node_id,
+                "worker_lane": record.worker_lane,
+                "targets": record.targets,
+                "depends_on": record.depends_on,
+                "state": record.state,
+            }
+            for record in records
+        ]
+    }
+    save_json_file(ownership_rules_path(), payload)
+
+
+def sync_dispatch_runtime_state(
+    *,
+    round_index: int,
+    inputs: dict[str, str],
+    dispatch_contract: dict[str, Any] | None,
+    reviewer_contract: dict[str, Any] | None,
+    decision_contract: dict[str, Any] | None,
+    execution_entries: list[dict[str, Any]],
+) -> None:
+    github_state = load_github_state()
+    node_workspaces = load_node_workspaces()
+    active_nodes = list_of_strings((dispatch_contract or {}).get("active_nodes", []))
+    inactive_nodes = list_of_strings((dispatch_contract or {}).get("inactive_nodes", []))
+    work_item_records = [
+        build_work_item_record(
+            item=item,
+            round_index=round_index,
+            decision_contract=decision_contract,
+            reviewer_contract=reviewer_contract,
+            execution_entries=execution_entries,
+            github_state=github_state,
+            node_workspaces=node_workspaces,
+        )
+        for item in active_work_items(dispatch_contract)
+    ]
+
+    if not active_nodes:
+        active_nodes = sorted(dict.fromkeys(record.node for record in work_item_records))
+    active_logical_nodes = sorted(
+        dict.fromkeys(
+            record.logical_node_id for record in work_item_records if record.logical_node_id
+        )
+    )
+
+    real_write_nodes = sorted(
+        dict.fromkeys(record.node for record in work_item_records if record.write_count > 0)
+    )
+    decision = str((decision_contract or {}).get("decision", "")).upper()
+    rerun_nodes = list_of_strings((decision_contract or {}).get("rerun_nodes", []))
+    reviewer_verdict = str((reviewer_contract or {}).get("verdict", "")).upper()
+
+    round_record = DispatchRoundRecord(
+        round_index=round_index,
+        mode=inputs.get("run_mode", "").strip() or inputs.get("mode", "").strip() or "",
+        execution_mode=inputs.get("execution_mode", "").strip(),
+        bootstrap_mode=inputs.get("bootstrap_mode", "").strip(),
+        bootstrap_fast_track=inputs.get("bootstrap_fast_track", "").strip().lower() == "true",
+        user_interface=str((dispatch_contract or {}).get("user_interface", "")).strip(),
+        active_nodes=active_nodes,
+        active_logical_nodes=active_logical_nodes,
+        inactive_nodes=inactive_nodes,
+        work_item_ids=[record.work_item_id for record in work_item_records],
+        retry_nodes=list_of_strings(inputs.get("retry_nodes", "").split(",")) if inputs.get("retry_nodes") else [],
+        retry_reason=inputs.get("retry_reason", "").strip(),
+        previous_round_summary=inputs.get("previous_round_summary", "").strip(),
+        reviewer_verdict=reviewer_verdict,
+        decision=decision,
+        rerun_nodes=rerun_nodes,
+        stop_reason=str((decision_contract or {}).get("stop_reason", "")).strip(),
+        real_write_nodes=real_write_nodes,
+        real_write_count=sum(record.write_count for record in work_item_records),
+        updated_at=now_iso(),
+    )
+
+    upsert_dispatch_rounds([round_record])
+    upsert_work_items(work_item_records)
+    save_pr_bindings(work_item_records)
+    save_ownership_rules(work_item_records)

--- a/src/multi_dev/tools/git_github_tools.py
+++ b/src/multi_dev/tools/git_github_tools.py
@@ -14,6 +14,15 @@ from typing import Any, Type
 from crewai.tools import BaseTool
 from pydantic import BaseModel, Field
 
+from multi_dev.tools.runtime_registry import (
+    load_json_file,
+    load_workspace_registry,
+    save_json_file,
+    save_workspace_registry,
+    set_workspace_binding,
+    workspace_binding_for,
+)
+
 
 def project_root() -> Path:
     return Path(__file__).resolve().parents[3]
@@ -56,23 +65,6 @@ def repo_workspace_slug(repo_root: Path) -> str:
     return f"{name or 'repo'}-{digest}"
 
 
-def load_json_file(path: Path, default: Any) -> Any:
-    if not path.exists():
-        return default
-    try:
-        return json.loads(path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError:
-        return default
-
-
-def save_json_file(path: Path, payload: Any) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(
-        json.dumps(payload, ensure_ascii=False, indent=2),
-        encoding="utf-8",
-    )
-
-
 def load_github_state() -> dict[str, Any]:
     return load_json_file(
         github_state_path(),
@@ -81,6 +73,7 @@ def load_github_state() -> dict[str, Any]:
             "issues": [],
             "pull_requests": [],
             "node_workspaces": {},
+            "workspaces_by_work_item": {},
             "repo_secrets": [],
             "pull_request_reviews": [],
         },
@@ -92,11 +85,11 @@ def save_github_state(payload: dict[str, Any]) -> None:
 
 
 def load_node_workspaces() -> dict[str, Any]:
-    return load_json_file(node_workspaces_path(), {})
+    return load_workspace_registry()
 
 
 def save_node_workspaces(payload: dict[str, Any]) -> None:
-    save_json_file(node_workspaces_path(), payload)
+    save_workspace_registry(payload)
 
 
 def github_token() -> str:
@@ -419,15 +412,20 @@ def upsert_repo_secret_state(secret_payload: dict[str, Any]) -> None:
 def set_node_workspace_state(node_name: str, payload: dict[str, Any]) -> None:
     state = load_github_state()
     state.setdefault("node_workspaces", {})[node_name] = payload
+    work_item_id = str(payload.get("work_item_id", "")).strip()
+    if work_item_id:
+        state.setdefault("workspaces_by_work_item", {})[work_item_id] = payload
     save_github_state(state)
 
-    workspaces = load_node_workspaces()
-    workspaces[node_name] = payload
-    save_node_workspaces(workspaces)
+    set_workspace_binding(
+        node_name=node_name,
+        payload=payload,
+        work_item_id=work_item_id,
+    )
 
 
-def workspace_for_node(node_name: str) -> dict[str, Any]:
-    return load_node_workspaces().get(node_name, {})
+def workspace_for_node(node_name: str, work_item_id: str = "") -> dict[str, Any]:
+    return workspace_binding_for(node_name=node_name, work_item_id=work_item_id)
 
 
 def cleanup_worktree_path(repo_root: Path, target_path: Path) -> None:
@@ -595,8 +593,10 @@ class GitHubCreateIssueInput(BaseModel):
     body: str = Field(..., description="Issue 正文。")
     labels: list[str] = Field(default_factory=list, description="Issue labels。")
     node_name: str = Field(default="", description="负责的 node。")
+    logical_node_id: str = Field(default="", description="逻辑 node id，例如 backend_node.catalog。")
     issue_key: str = Field(default="", description="内部 Issue ID，例如 MVP-001。")
     branch_name: str = Field(default="", description="建议绑定的分支名。")
+    work_item_id: str = Field(default="", description="work item id。")
 
 
 class GitHubCreateIssueTool(BaseTool):
@@ -612,8 +612,10 @@ class GitHubCreateIssueTool(BaseTool):
         body: str,
         labels: list[str] | None = None,
         node_name: str = "",
+        logical_node_id: str = "",
         issue_key: str = "",
         branch_name: str = "",
+        work_item_id: str = "",
     ) -> str:
         owner, repo = repo_state()
         payload = {
@@ -631,8 +633,10 @@ class GitHubCreateIssueTool(BaseTool):
             "title": response.get("title", title),
             "html_url": response.get("html_url", ""),
             "node": node_name,
+            "logical_node_id": logical_node_id,
             "issue_key": issue_key,
             "branch_name": branch_name,
+            "work_item_id": work_item_id or issue_key,
             "status": "open",
         }
         upsert_issue_state(issue_payload)
@@ -705,6 +709,8 @@ class GitHubSyncCICDSecretsTool(BaseTool):
 class GitPrepareWorkspaceInput(BaseModel):
     node_name: str = Field(..., description="节点名称，如 backend_node。")
     branch_name: str = Field(..., description="该 node 专属分支名。")
+    work_item_id: str = Field(default="", description="work item id。")
+    logical_node_id: str = Field(default="", description="逻辑 node id。")
     issue_number: int = Field(default=0, ge=0, description="关联的 GitHub issue 编号。")
     base_branch: str = Field(default="main", description="从哪个基础分支切出。")
     worktree_path: str = Field(default="", description="可选，显式指定 worktree 目录。")
@@ -722,6 +728,8 @@ class GitPrepareWorkspaceTool(BaseTool):
         self,
         node_name: str,
         branch_name: str,
+        work_item_id: str = "",
+        logical_node_id: str = "",
         issue_number: int = 0,
         base_branch: str = "main",
         worktree_path: str = "",
@@ -739,7 +747,9 @@ class GitPrepareWorkspaceTool(BaseTool):
             else (
                 worktrees_root()
                 / repo_slug
-                / f"{node_name}-{sanitized_branch_fragment(branch_name)}"
+                / (
+                    f"{node_name}-{sanitized_branch_fragment(work_item_id or logical_node_id or branch_name)}"
+                )
             ).resolve()
         )
 
@@ -757,6 +767,8 @@ class GitPrepareWorkspaceTool(BaseTool):
 
         payload = {
             "node_name": node_name,
+            "logical_node_id": logical_node_id,
+            "work_item_id": work_item_id,
             "branch_name": branch_name,
             "issue_number": issue_number,
             "base_branch": base_branch,
@@ -765,6 +777,8 @@ class GitPrepareWorkspaceTool(BaseTool):
         set_node_workspace_state(node_name, payload)
         return (
             f"Node workspace 已准备：{node_name}\n"
+            f"- work_item_id: {work_item_id or '未绑定'}\n"
+            f"- logical_node_id: {logical_node_id or '未指定'}\n"
             f"- branch: {branch_name}\n"
             f"- worktree: {target_path}\n"
             f"- issue_number: {issue_number or '未绑定'}"
@@ -774,6 +788,7 @@ class GitPrepareWorkspaceTool(BaseTool):
 class GitCommitAndPushInput(BaseModel):
     node_name: str = Field(..., description="节点名称。")
     commit_message: str = Field(..., description="提交信息。")
+    work_item_id: str = Field(default="", description="work item id。")
     branch_name: str = Field(default="", description="显式分支名；默认取 node workspace 记录。")
 
 
@@ -788,11 +803,15 @@ class GitCommitAndPushTool(BaseTool):
         self,
         node_name: str,
         commit_message: str,
+        work_item_id: str = "",
         branch_name: str = "",
     ) -> str:
-        workspace = workspace_for_node(node_name)
+        workspace = workspace_for_node(node_name, work_item_id=work_item_id)
         if not workspace:
-            raise RuntimeError(f"未找到 node workspace：{node_name}")
+            raise RuntimeError(
+                f"未找到 node workspace：{node_name}"
+                + (f" / {work_item_id}" if work_item_id else "")
+            )
 
         repo_root = Path(workspace["worktree_path"]).resolve()
         resolved_branch = branch_name or str(workspace.get("branch_name", "")).strip()
@@ -809,12 +828,17 @@ class GitCommitAndPushTool(BaseTool):
         state = load_github_state()
         issues = state.setdefault("issues", [])
         for issue in issues:
-            if issue.get("node") == node_name:
-                issue["status"] = "in_review"
+            if work_item_id:
+                if str(issue.get("work_item_id", "")).strip() != work_item_id:
+                    continue
+            elif issue.get("node") != node_name:
+                continue
+            issue["status"] = "in_review"
         save_github_state(state)
 
         return (
             f"{node_name} 已提交并推送。\n"
+            f"- work_item_id: {work_item_id or str(workspace.get('work_item_id', '')).strip() or '未绑定'}\n"
             f"- branch: {resolved_branch}\n"
             f"- commit: {detail}"
         )
@@ -822,6 +846,8 @@ class GitCommitAndPushTool(BaseTool):
 
 class GitHubCreateOrUpdatePRInput(BaseModel):
     node_name: str = Field(..., description="节点名称。")
+    logical_node_id: str = Field(default="", description="逻辑 node id。")
+    work_item_id: str = Field(default="", description="work item id。")
     title: str = Field(..., description="PR 标题。")
     body: str = Field(..., description="PR 正文。")
     head_branch: str = Field(..., description="head branch。")
@@ -846,6 +872,8 @@ class GitHubCreateOrUpdatePRTool(BaseTool):
         base_branch: str = "main",
         issue_number: int = 0,
         draft: bool = False,
+        logical_node_id: str = "",
+        work_item_id: str = "",
     ) -> str:
         owner, repo = repo_state()
         query = urllib.parse.urlencode(
@@ -888,6 +916,8 @@ class GitHubCreateOrUpdatePRTool(BaseTool):
             "title": pr.get("title", title),
             "html_url": pr.get("html_url", ""),
             "node": node_name,
+            "logical_node_id": logical_node_id,
+            "work_item_id": work_item_id,
             "head_branch": head_branch,
             "base_branch": base_branch,
             "issue_number": issue_number,
@@ -895,18 +925,24 @@ class GitHubCreateOrUpdatePRTool(BaseTool):
         }
         upsert_pr_state(pr_payload)
 
-        if issue_number:
+        if issue_number or work_item_id:
             state = load_github_state()
             for issue in state.setdefault("issues", []):
-                if issue.get("number") == issue_number:
-                    issue["pr_number"] = pr_payload["number"]
-                    issue["status"] = "in_review"
+                if issue_number and issue.get("number") != issue_number:
+                    continue
+                if work_item_id and str(issue.get("work_item_id", "")).strip() != work_item_id:
+                    continue
+                issue["status"] = "in_review"
+                issue["pr_number"] = pr_payload["number"]
+                issue["status"] = "in_review"
             save_github_state(state)
 
         return (
             f"PR 已就绪：#{pr_payload['number']} {pr_payload['title']}\n"
             f"- url: {pr_payload['html_url']}\n"
             f"- node: {node_name}\n"
+            f"- logical_node_id: {logical_node_id or '未指定'}\n"
+            f"- work_item_id: {work_item_id or '未绑定'}\n"
             f"- head: {head_branch}\n"
             f"- base: {base_branch}"
         )

--- a/src/multi_dev/tools/git_github_tools.py
+++ b/src/multi_dev/tools/git_github_tools.py
@@ -8,6 +8,7 @@ import subprocess
 import urllib.error
 import urllib.parse
 import urllib.request
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Type
 
@@ -293,6 +294,33 @@ def git_push_branch(repo_root: Path, branch_name: str, set_upstream: bool = True
     run_git(args, cwd=repo_root)
 
 
+def git_branch_diff_payload(
+    repo_root: Path,
+    branch_name: str,
+    base_branch: str = "main",
+    max_lines: int = 200,
+) -> dict[str, str]:
+    stat = run_git(
+        ["diff", "--stat", f"{base_branch}...{branch_name}"],
+        cwd=repo_root,
+        check=False,
+    ).strip()
+    patch = run_git(
+        ["diff", f"{base_branch}...{branch_name}"],
+        cwd=repo_root,
+        check=False,
+    )
+    patch_lines = patch.splitlines()
+    if len(patch_lines) > max_lines:
+        patch = "\n".join(patch_lines[:max_lines]) + "\n...[truncated]"
+    return {
+        "branch": branch_name,
+        "base": base_branch,
+        "stat": stat or "<no diff stat>",
+        "patch": patch.strip() or "<no patch>",
+    }
+
+
 def ensure_local_branch(repo_root: Path, branch_name: str, base_branch: str) -> None:
     local_branches = run_git(["branch", "--list", branch_name], cwd=repo_root, check=False)
     if local_branches.strip():
@@ -381,6 +409,18 @@ def upsert_pr_state(pr_payload: dict[str, Any]) -> None:
             return
     prs.append(pr_payload)
     save_github_state(state)
+
+
+def append_execution_log(action: str, relative_path: str, details: dict[str, Any]) -> None:
+    path = outputs_dir() / "execution_log.jsonl"
+    entry = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "action": action,
+        "path": relative_path,
+        "details": details,
+    }
+    with path.open("a", encoding="utf-8") as file_handle:
+        file_handle.write(json.dumps(entry, ensure_ascii=False) + "\n")
 
 
 def upsert_pr_review_state(review_payload: dict[str, Any]) -> None:
@@ -867,6 +907,22 @@ class GitCommitAndPushTool(BaseTool):
             return f"{node_name} 没有需要提交的改动。"
 
         git_push_branch(repo_root, resolved_branch, set_upstream=True)
+        diff_payload = git_branch_diff_payload(
+            repo_root=repo_root,
+            branch_name=resolved_branch,
+            base_branch=str(workspace.get("base_branch", "")).strip() or "main",
+        )
+        append_execution_log(
+            action="git_branch_diff_summary",
+            relative_path=resolved_branch,
+            details={
+                "node": node_name,
+                "work_item_id": work_item_id or str(workspace.get("work_item_id", "")).strip(),
+                "logical_node_id": str(workspace.get("logical_node_id", "")).strip(),
+                "base_branch": diff_payload["base"],
+                "stat": diff_payload["stat"],
+            },
+        )
 
         state = load_github_state()
         issues = state.setdefault("issues", [])
@@ -877,13 +933,18 @@ class GitCommitAndPushTool(BaseTool):
             elif issue.get("node") != node_name:
                 continue
             issue["status"] = "in_review"
+            issue["diff_summary"] = diff_payload
+        for pr in state.setdefault("pull_requests", []):
+            if work_item_id and str(pr.get("work_item_id", "")).strip() == work_item_id:
+                pr["diff_summary"] = diff_payload
         save_github_state(state)
 
         return (
             f"{node_name} 已提交并推送。\n"
             f"- work_item_id: {work_item_id or str(workspace.get('work_item_id', '')).strip() or '未绑定'}\n"
             f"- branch: {resolved_branch}\n"
-            f"- commit: {detail}"
+            f"- commit: {detail}\n"
+            f"- diff_stat: {diff_payload['stat']}"
         )
 
 

--- a/src/multi_dev/tools/git_github_tools.py
+++ b/src/multi_dev/tools/git_github_tools.py
@@ -444,6 +444,54 @@ def cleanup_worktree_path(repo_root: Path, target_path: Path) -> None:
                 pass
 
 
+def default_worktree_path(
+    repo_root: Path,
+    *,
+    node_name: str,
+    work_item_id: str,
+    logical_node_id: str,
+    branch_name: str,
+) -> Path:
+    repo_slug = repo_workspace_slug(repo_root)
+    return (
+        worktrees_root()
+        / repo_slug
+        / f"{node_name}-{sanitized_branch_fragment(work_item_id or logical_node_id or branch_name)}"
+    ).resolve()
+
+
+def resolve_worktree_target_path(
+    repo_root: Path,
+    *,
+    node_name: str,
+    work_item_id: str,
+    logical_node_id: str,
+    branch_name: str,
+    requested_path: str,
+) -> Path:
+    default_path = default_worktree_path(
+        repo_root,
+        node_name=node_name,
+        work_item_id=work_item_id,
+        logical_node_id=logical_node_id,
+        branch_name=branch_name,
+    )
+    clean_requested = requested_path.strip()
+    if not clean_requested:
+        return default_path
+
+    candidate = Path(clean_requested).expanduser()
+    if not candidate.is_absolute():
+        candidate = (worktrees_root() / candidate).resolve()
+    else:
+        candidate = candidate.resolve()
+
+    safe_root = worktrees_root().resolve()
+    if candidate == safe_root or safe_root in candidate.parents:
+        return candidate
+    return default_path
+
+
 def github_repo_public_key(owner: str, repo: str) -> dict[str, Any]:
     response = github_api_request(
         "GET",
@@ -739,18 +787,13 @@ class GitPrepareWorkspaceTool(BaseTool):
         ensure_local_git_identity(repo_root)
         git_fetch_origin(repo_root)
         ensure_local_branch(repo_root, branch_name, base_branch)
-        repo_slug = repo_workspace_slug(repo_root)
-
-        target_path = (
-            Path(worktree_path).expanduser().resolve()
-            if worktree_path.strip()
-            else (
-                worktrees_root()
-                / repo_slug
-                / (
-                    f"{node_name}-{sanitized_branch_fragment(work_item_id or logical_node_id or branch_name)}"
-                )
-            ).resolve()
+        target_path = resolve_worktree_target_path(
+            repo_root,
+            node_name=node_name,
+            work_item_id=work_item_id,
+            logical_node_id=logical_node_id,
+            branch_name=branch_name,
+            requested_path=worktree_path,
         )
 
         if target_path.exists():

--- a/src/multi_dev/tools/repo_execution_tools.py
+++ b/src/multi_dev/tools/repo_execution_tools.py
@@ -15,6 +15,7 @@ from multi_dev.tools.runtime_registry import (
     dispatched_work_items_for_node,
     workspace_binding_for,
 )
+from multi_dev.tools.git_github_tools import GitPrepareWorkspaceTool
 
 
 IGNORED_PARTS = {
@@ -81,6 +82,7 @@ def execution_log_path() -> Path:
 
 
 def target_repository_root(node_name: str = "") -> Path:
+    ensure_workspace_ready_for_access(node_name)
     if node_name:
         workspace = workspace_binding_for(node_name=node_name)
         if isinstance(workspace, dict):
@@ -176,6 +178,48 @@ def ensure_workspace_ready_for_write(node_name: str) -> None:
     clean_node_name = str(node_name).strip()
     if not clean_node_name or execution_mode() != "write" or not github_enabled():
         return
+    dispatched_items = dispatched_work_items_for_node(clean_node_name)
+    if not dispatched_items:
+        return
+    workspace = workspace_binding_for(node_name=clean_node_name)
+    worktree_path = str(workspace.get("worktree_path", "")).strip()
+    if worktree_path:
+        root = Path(worktree_path).expanduser()
+        if root.exists() and root.is_dir():
+            return
+
+    primary_item = dispatched_items[0]
+    branch_name = str(primary_item.get("branch_name", "")).strip()
+    logical_node_id = str(primary_item.get("logical_node_id", "")).strip()
+    work_item_id = str(primary_item.get("work_item_id", "")).strip()
+    github_issue_number = int(primary_item.get("github_issue_number", 0) or 0)
+    worktree_path = str(primary_item.get("worktree_path", "")).strip()
+    if branch_name:
+        GitPrepareWorkspaceTool()._run(
+            node_name=clean_node_name,
+            branch_name=branch_name,
+            work_item_id=work_item_id,
+            logical_node_id=logical_node_id,
+            issue_number=github_issue_number,
+            base_branch="main",
+            worktree_path=worktree_path,
+        )
+        workspace = workspace_binding_for(node_name=clean_node_name)
+        resolved_worktree_path = str(workspace.get("worktree_path", "")).strip()
+        if resolved_worktree_path:
+            root = Path(resolved_worktree_path).expanduser()
+            if root.exists() and root.is_dir():
+                return
+    raise RuntimeError(
+        f"{clean_node_name} 在执行写入前必须先调用 `git_prepare_node_workspace`，"
+        "当前未找到可用 worktree。"
+    )
+
+
+def ensure_workspace_ready_for_access(node_name: str) -> None:
+    clean_node_name = str(node_name).strip()
+    if not clean_node_name or execution_mode() != "write" or not github_enabled():
+        return
     if not dispatched_work_items_for_node(clean_node_name):
         return
     workspace = workspace_binding_for(node_name=clean_node_name)
@@ -184,10 +228,7 @@ def ensure_workspace_ready_for_write(node_name: str) -> None:
         root = Path(worktree_path).expanduser()
         if root.exists() and root.is_dir():
             return
-    raise RuntimeError(
-        f"{clean_node_name} 在执行写入前必须先调用 `git_prepare_node_workspace`，"
-        "当前未找到可用 worktree。"
-    )
+    ensure_workspace_ready_for_write(clean_node_name)
 
 
 def resolve_repo_path(

--- a/src/multi_dev/tools/repo_execution_tools.py
+++ b/src/multi_dev/tools/repo_execution_tools.py
@@ -1,12 +1,18 @@
 import json
 import os
-import re
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Type
 
 from crewai.tools import BaseTool
 from pydantic import BaseModel, Field
+
+from multi_dev.tools.runtime_registry import (
+    active_work_item_id_for_node,
+    approved_targets_for_node as approved_dispatch_targets_for_node,
+    base_node_name,
+    workspace_binding_for,
+)
 
 
 IGNORED_PARTS = {
@@ -72,24 +78,9 @@ def execution_log_path() -> Path:
     return outputs_dir() / "execution_log.jsonl"
 
 
-def node_workspaces_path() -> Path:
-    return outputs_dir() / "node_workspaces.json"
-
-
-def load_node_workspaces() -> dict[str, object]:
-    path = node_workspaces_path()
-    if not path.exists():
-        return {}
-    try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError:
-        return {}
-    return payload if isinstance(payload, dict) else {}
-
-
 def target_repository_root(node_name: str = "") -> Path:
     if node_name:
-        workspace = load_node_workspaces().get(node_name, {})
+        workspace = workspace_binding_for(node_name=node_name)
         if isinstance(workspace, dict):
             worktree_path = str(workspace.get("worktree_path", "")).strip()
             if worktree_path:
@@ -153,6 +144,15 @@ def should_ignore(relative_path: Path) -> bool:
 
 
 def append_execution_log(action: str, relative_path: str, details: dict[str, str]) -> None:
+    node_name = str(details.get("node", "")).strip()
+    if node_name:
+        workspace = workspace_binding_for(node_name=node_name)
+        work_item_id = str(workspace.get("work_item_id", "")).strip()
+        logical_node_id = str(workspace.get("logical_node_id", "")).strip()
+        if work_item_id and "work_item_id" not in details:
+            details["work_item_id"] = work_item_id
+        if logical_node_id and "logical_node_id" not in details:
+            details["logical_node_id"] = logical_node_id
     entry = {
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "action": action,
@@ -194,55 +194,14 @@ def path_matches_prefix(relative: Path, prefix: str) -> bool:
     )
 
 
-def extract_json_block(markdown_text: str) -> dict[str, object] | None:
-    patterns = [
-        r"```json\s*(\{.*?\})\s*```",
-        r"```JSON\s*(\{.*?\})\s*```",
-    ]
-    for pattern in patterns:
-        matches = re.findall(pattern, markdown_text, flags=re.DOTALL)
-        for candidate in reversed(matches):
-            try:
-                parsed = json.loads(candidate)
-            except json.JSONDecodeError:
-                continue
-            if isinstance(parsed, dict):
-                return parsed
-    return None
-
-
 def approved_targets_for_node(node_name: str) -> tuple[str, ...]:
     if not node_name:
         return ()
-
-    dispatch_path = outputs_dir() / "master_dispatch.md"
-    if not dispatch_path.exists():
-        return ()
-
-    contract = extract_json_block(
-        dispatch_path.read_text(encoding="utf-8", errors="ignore")
+    work_item_id = active_work_item_id_for_node(node_name)
+    targets = approved_dispatch_targets_for_node(
+        node_name,
+        work_item_id=work_item_id,
     )
-    if not contract:
-        return ()
-
-    work_items = contract.get("work_items", [])
-    if not isinstance(work_items, list):
-        return ()
-
-    approved_targets: list[str] = []
-    for item in work_items:
-        if not isinstance(item, dict):
-            continue
-        if str(item.get("node", "")).strip() != node_name:
-            continue
-
-        targets = item.get("targets", [])
-        if isinstance(targets, list):
-            for target in targets:
-                if isinstance(target, str) and target.strip():
-                    approved_targets.append(target.strip().strip("/"))
-
-    targets = tuple(dict.fromkeys(target for target in approved_targets if target))
     if not bootstrap_fast_track_enabled():
         return targets
 
@@ -251,6 +210,7 @@ def approved_targets_for_node(node_name: str) -> tuple[str, ...]:
 
 
 def bootstrap_template_targets_for_node(node_name: str) -> tuple[str, ...]:
+    resolved_node_name = base_node_name(node_name)
     package_name = bootstrap_package_name()
     shared_backend = (
         "pyproject.toml",
@@ -275,11 +235,11 @@ def bootstrap_template_targets_for_node(node_name: str) -> tuple[str, ...]:
         ".github/workflows/deploy.yml",
     )
 
-    if node_name == "backend_node":
+    if resolved_node_name == "backend_node":
         return shared_backend
-    if node_name == "frontend_node":
+    if resolved_node_name == "frontend_node":
         return shared_frontend
-    if node_name == "tester_node":
+    if resolved_node_name == "tester_node":
         return shared_tester
     return ()
 

--- a/src/multi_dev/tools/repo_execution_tools.py
+++ b/src/multi_dev/tools/repo_execution_tools.py
@@ -12,6 +12,7 @@ from multi_dev.tools.runtime_registry import (
     active_work_item_id_for_node,
     approved_targets_for_node as approved_dispatch_targets_for_node,
     base_node_name,
+    dispatched_work_items_for_node,
     workspace_binding_for,
 )
 
@@ -162,6 +163,31 @@ def append_execution_log(action: str, relative_path: str, details: dict[str, str
     }
     with execution_log_path().open("a", encoding="utf-8") as file_handle:
         file_handle.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+
+def github_enabled() -> bool:
+    value = os.getenv("GITHUB_ENABLED", "").strip().lower()
+    if value:
+        return value in {"1", "true", "yes", "on"}
+    return bool(os.getenv("GITHUB_TOKEN", "").strip() and os.getenv("GITHUB_OWNER", "").strip())
+
+
+def ensure_workspace_ready_for_write(node_name: str) -> None:
+    clean_node_name = str(node_name).strip()
+    if not clean_node_name or execution_mode() != "write" or not github_enabled():
+        return
+    if not dispatched_work_items_for_node(clean_node_name):
+        return
+    workspace = workspace_binding_for(node_name=clean_node_name)
+    worktree_path = str(workspace.get("worktree_path", "")).strip()
+    if worktree_path:
+        root = Path(worktree_path).expanduser()
+        if root.exists() and root.is_dir():
+            return
+    raise RuntimeError(
+        f"{clean_node_name} 在执行写入前必须先调用 `git_prepare_node_workspace`，"
+        "当前未找到可用 worktree。"
+    )
 
 
 def resolve_repo_path(
@@ -421,6 +447,7 @@ class MakeRepoDirectoryTool(BaseTool):
     def _run(self, relative_path: str) -> str:
         if execution_mode() != "write":
             return "拒绝创建目录：当前 CREW_EXECUTION_MODE 不是 `write`。"
+        ensure_workspace_ready_for_write(self.node_name)
 
         _, path, relative = resolve_repo_path(relative_path, node_name=self.node_name)
         ensure_allowed_prefix(
@@ -454,6 +481,7 @@ class WriteRepoFileTool(BaseTool):
     def _run(self, relative_path: str, content: str) -> str:
         if execution_mode() != "write":
             return "拒绝写入：当前 CREW_EXECUTION_MODE 不是 `write`。"
+        ensure_workspace_ready_for_write(self.node_name)
 
         _, path, relative = resolve_repo_path(relative_path, node_name=self.node_name)
         ensure_allowed_prefix(
@@ -503,6 +531,7 @@ class ReplaceRepoTextTool(BaseTool):
     ) -> str:
         if execution_mode() != "write":
             return "拒绝替换：当前 CREW_EXECUTION_MODE 不是 `write`。"
+        ensure_workspace_ready_for_write(self.node_name)
 
         _, path, relative = resolve_repo_path(relative_path, node_name=self.node_name)
         ensure_allowed_prefix(

--- a/src/multi_dev/tools/repo_execution_tools.py
+++ b/src/multi_dev/tools/repo_execution_tools.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Type
@@ -183,6 +184,21 @@ def normalize_prefixes(prefixes: tuple[str, ...]) -> tuple[str, ...]:
     return tuple(cleaned)
 
 
+def expand_glob_patterns(glob_pattern: str) -> tuple[str, ...]:
+    pattern = str(glob_pattern).strip() or "**/*"
+    match = re.search(r"\{([^{}]+)\}", pattern)
+    if not match:
+        return (pattern,)
+
+    prefix = pattern[: match.start()]
+    suffix = pattern[match.end() :]
+    variants = [item.strip() for item in match.group(1).split(",") if item.strip()]
+    expanded: list[str] = []
+    for variant in variants:
+        expanded.extend(expand_glob_patterns(prefix + variant + suffix))
+    return tuple(dict.fromkeys(expanded))
+
+
 def path_matches_prefix(relative: Path, prefix: str) -> bool:
     normalized_prefix = prefix.strip().strip("/")
     if not normalized_prefix:
@@ -295,7 +311,18 @@ class ListRepoFilesTool(BaseTool):
         root = target_repository_root(node_name=self.node_name)
         matches: list[str] = []
 
-        for path in sorted(root.glob(glob_pattern)):
+        expanded_patterns = expand_glob_patterns(glob_pattern)
+        seen: set[str] = set()
+        all_paths: list[Path] = []
+        for pattern in expanded_patterns:
+            for path in root.glob(pattern):
+                marker = str(path)
+                if marker in seen:
+                    continue
+                seen.add(marker)
+                all_paths.append(path)
+
+        for path in sorted(all_paths):
             try:
                 relative = path.relative_to(root)
             except ValueError:

--- a/src/multi_dev/tools/runtime_registry.py
+++ b/src/multi_dev/tools/runtime_registry.py
@@ -210,6 +210,20 @@ def lane_index_for_node_name(node_name: str) -> int:
     return 1
 
 
+def worker_lane_aliases_for_node_name(node_name: str) -> set[str]:
+    clean = str(node_name).strip()
+    base_name = base_node_name(clean)
+    lane_index = lane_index_for_node_name(clean)
+    aliases = {clean}
+    if base_name == "backend_node":
+        aliases.update({"backend", f"backend_{lane_index}"})
+    elif base_name == "frontend_node":
+        aliases.update({"frontend", f"frontend_{lane_index}"})
+    elif base_name == "tester_node":
+        aliases.update({"tester", f"tester_{lane_index}"})
+    return {alias for alias in aliases if alias}
+
+
 def dispatched_work_items_for_node(
     node_name: str,
     *,
@@ -227,6 +241,7 @@ def dispatched_work_items_for_node(
     clean_node_name = str(node_name).strip()
     requested_base_node = base_node_name(clean_node_name)
     requested_lane = lane_index_for_node_name(clean_node_name)
+    requested_lane_aliases = worker_lane_aliases_for_node_name(clean_node_name)
     lane_mode = requested_base_node != clean_node_name
 
     matches: list[dict[str, Any]] = []
@@ -244,7 +259,7 @@ def dispatched_work_items_for_node(
         item_worker_lane = str(item.get("worker_lane", "")).strip()
         if lane_mode:
             if item_worker_lane:
-                if item_worker_lane != clean_node_name:
+                if item_worker_lane not in requested_lane_aliases:
                     continue
             elif requested_lane != 1:
                 continue

--- a/src/multi_dev/tools/runtime_registry.py
+++ b/src/multi_dev/tools/runtime_registry.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+EXECUTION_NODE_TYPES = ("backend_node", "frontend_node", "tester_node")
+
+
+def project_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def outputs_dir() -> Path:
+    path = project_root() / "outputs"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def load_json_file(path: Path, default: Any) -> Any:
+    if not path.exists():
+        return default
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return default
+
+
+def save_json_file(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+
+def extract_json_block(markdown_text: str) -> dict[str, object] | None:
+    patterns = [
+        r"```json\s*(\{.*?\})\s*```",
+        r"```JSON\s*(\{.*?\})\s*```",
+    ]
+    for pattern in patterns:
+        matches = re.findall(pattern, markdown_text, flags=re.DOTALL)
+        for candidate in reversed(matches):
+            try:
+                parsed = json.loads(candidate)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(parsed, dict):
+                return parsed
+    return None
+
+
+def dispatch_contract_path() -> Path:
+    return outputs_dir() / "master_dispatch.md"
+
+
+def dispatch_contract_or_none() -> dict[str, object] | None:
+    path = dispatch_contract_path()
+    if not path.exists():
+        return None
+    return extract_json_block(path.read_text(encoding="utf-8", errors="ignore"))
+
+
+def node_workspaces_path() -> Path:
+    return outputs_dir() / "node_workspaces.json"
+
+
+def empty_workspace_registry() -> dict[str, Any]:
+    return {
+        "schema_version": 2,
+        "by_node": {},
+        "by_work_item": {},
+        "active_work_item_by_node": {},
+    }
+
+
+def normalize_workspace_registry(payload: Any) -> dict[str, Any]:
+    default = empty_workspace_registry()
+    if not isinstance(payload, dict):
+        return default
+
+    if (
+        "schema_version" in payload
+        or "by_node" in payload
+        or "by_work_item" in payload
+        or "active_work_item_by_node" in payload
+    ):
+        return {
+            "schema_version": int(payload.get("schema_version", 2) or 2),
+            "by_node": payload.get("by_node", {}) if isinstance(payload.get("by_node", {}), dict) else {},
+            "by_work_item": payload.get("by_work_item", {}) if isinstance(payload.get("by_work_item", {}), dict) else {},
+            "active_work_item_by_node": (
+                payload.get("active_work_item_by_node", {})
+                if isinstance(payload.get("active_work_item_by_node", {}), dict)
+                else {}
+            ),
+        }
+
+    legacy_by_node: dict[str, Any] = {}
+    for key, value in payload.items():
+        if not isinstance(value, dict):
+            continue
+        legacy_by_node[str(key).strip()] = value
+
+    return {
+        "schema_version": 2,
+        "by_node": legacy_by_node,
+        "by_work_item": {},
+        "active_work_item_by_node": {},
+    }
+
+
+def load_workspace_registry() -> dict[str, Any]:
+    return normalize_workspace_registry(
+        load_json_file(node_workspaces_path(), empty_workspace_registry())
+    )
+
+
+def save_workspace_registry(payload: dict[str, Any]) -> None:
+    save_json_file(node_workspaces_path(), normalize_workspace_registry(payload))
+
+
+def workspace_binding_for(
+    *,
+    node_name: str = "",
+    work_item_id: str = "",
+) -> dict[str, Any]:
+    registry = load_workspace_registry()
+    by_work_item = registry.get("by_work_item", {})
+    if work_item_id and isinstance(by_work_item, dict):
+        binding = by_work_item.get(work_item_id, {})
+        if isinstance(binding, dict) and binding:
+            return binding
+
+    active = registry.get("active_work_item_by_node", {})
+    if node_name and isinstance(active, dict):
+        active_work_item_id = str(active.get(node_name, "")).strip()
+        if active_work_item_id and isinstance(by_work_item, dict):
+            binding = by_work_item.get(active_work_item_id, {})
+            if isinstance(binding, dict) and binding:
+                return binding
+
+    by_node = registry.get("by_node", {})
+    if node_name and isinstance(by_node, dict):
+        binding = by_node.get(node_name, {})
+        if isinstance(binding, dict):
+            return binding
+
+    return {}
+
+
+def active_work_item_id_for_node(node_name: str) -> str:
+    if not node_name:
+        return ""
+    registry = load_workspace_registry()
+    active = registry.get("active_work_item_by_node", {})
+    if not isinstance(active, dict):
+        return ""
+    return str(active.get(node_name, "")).strip()
+
+
+def set_workspace_binding(
+    *,
+    node_name: str,
+    payload: dict[str, Any],
+    work_item_id: str = "",
+) -> dict[str, Any]:
+    registry = load_workspace_registry()
+    normalized_payload = dict(payload)
+    if work_item_id:
+        normalized_payload["work_item_id"] = work_item_id
+    registry.setdefault("by_node", {})[node_name] = normalized_payload
+    if work_item_id:
+        registry.setdefault("by_work_item", {})[work_item_id] = normalized_payload
+        registry.setdefault("active_work_item_by_node", {})[node_name] = work_item_id
+    save_workspace_registry(registry)
+    return registry
+
+
+def list_of_strings(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item).strip() for item in value if str(item).strip()]
+
+
+def base_node_name(node_name: str) -> str:
+    clean = str(node_name).strip()
+    if not clean:
+        return ""
+    for base_name in EXECUTION_NODE_TYPES:
+        if clean == base_name:
+            return base_name
+        if clean.startswith(f"{base_name}.") or clean.startswith(f"{base_name}__"):
+            return base_name
+        if clean.startswith(f"{base_name}_"):
+            return base_name
+    return clean
+
+
+def lane_index_for_node_name(node_name: str) -> int:
+    clean = str(node_name).strip()
+    match = re.search(r"__(\d+)$", clean)
+    if match:
+        try:
+            return max(1, int(match.group(1)))
+        except ValueError:
+            return 1
+    return 1
+
+
+def dispatched_work_items_for_node(
+    node_name: str,
+    *,
+    work_item_id: str = "",
+    logical_node_id: str = "",
+) -> list[dict[str, Any]]:
+    contract = dispatch_contract_or_none()
+    if not isinstance(contract, dict):
+        return []
+
+    work_items = contract.get("work_items", [])
+    if not isinstance(work_items, list):
+        return []
+
+    clean_node_name = str(node_name).strip()
+    requested_base_node = base_node_name(clean_node_name)
+    requested_lane = lane_index_for_node_name(clean_node_name)
+    lane_mode = requested_base_node != clean_node_name
+
+    matches: list[dict[str, Any]] = []
+    for item in work_items:
+        if not isinstance(item, dict):
+            continue
+        item_node = str(item.get("node", "")).strip()
+        item_base_node = base_node_name(item_node)
+        if item_node != clean_node_name and item_base_node != requested_base_node:
+            continue
+        item_work_item_id = str(
+            item.get("work_item_id") or item.get("issue_id") or ""
+        ).strip()
+        item_logical_node_id = str(item.get("logical_node_id", "")).strip()
+        item_worker_lane = str(item.get("worker_lane", "")).strip()
+        if lane_mode:
+            if item_worker_lane:
+                if item_worker_lane != clean_node_name:
+                    continue
+            elif requested_lane != 1:
+                continue
+        if work_item_id and item_work_item_id != work_item_id:
+            continue
+        if logical_node_id and item_logical_node_id != logical_node_id:
+            continue
+        matches.append(item)
+    return matches
+
+
+def approved_targets_for_node(
+    node_name: str,
+    *,
+    work_item_id: str = "",
+    logical_node_id: str = "",
+) -> tuple[str, ...]:
+    approved_targets: list[str] = []
+    for item in dispatched_work_items_for_node(
+        node_name,
+        work_item_id=work_item_id,
+        logical_node_id=logical_node_id,
+    ):
+        targets = item.get("targets", [])
+        if not isinstance(targets, list):
+            continue
+        for target in targets:
+            if isinstance(target, str) and target.strip():
+                approved_targets.append(target.strip().strip("/"))
+    return tuple(dict.fromkeys(target for target in approved_targets if target))

--- a/tests/test_parallel_dispatch.py
+++ b/tests/test_parallel_dispatch.py
@@ -1,0 +1,63 @@
+import unittest
+
+from multi_dev.crew import default_worktree_path_for, normalize_worker_lane_name
+from multi_dev.main import review_body_for_pr, should_skip_review
+from multi_dev.tools.runtime_registry import worker_lane_aliases_for_node_name
+
+
+class ParallelDispatchTests(unittest.TestCase):
+    def test_default_worktree_path_stays_inside_repo_outputs(self) -> None:
+        path = default_worktree_path_for(
+            "frontend_node__1",
+            "MVP-002",
+            "frontend_node__1.hero",
+            "codex/mvp-002",
+        )
+        self.assertIn("/multi_dev/outputs/worktrees/", path)
+
+    def test_normalize_worker_lane_keeps_lane_node_name(self) -> None:
+        normalized = normalize_worker_lane_name(
+            "frontend_node__1",
+            "frontend_node__1.hero",
+            "frontend_1",
+            1,
+        )
+        self.assertEqual(normalized, "frontend_node__1")
+
+    def test_worker_lane_aliases_match_lane_and_legacy_aliases(self) -> None:
+        aliases = worker_lane_aliases_for_node_name("frontend_node__2")
+        self.assertIn("frontend_node__2", aliases)
+        self.assertIn("frontend_2", aliases)
+        self.assertIn("frontend", aliases)
+
+    def test_review_body_for_rework_contains_matching_rework_item(self) -> None:
+        body = review_body_for_pr(
+            decision="REWORK",
+            pr_payload={
+                "node": "frontend_node__2",
+                "logical_node_id": "frontend_node__2.cart",
+                "work_item_id": "MVP-003",
+            },
+            reviewer_contract={
+                "rework_items": [
+                    "frontend_node__2 需要改回真实购物车入口文件",
+                    "backend_node 需要补 health version",
+                ]
+            },
+            decision_contract={"stop_reason": "review_failed"},
+        )
+        self.assertIn("REQUEST_CHANGES", body)
+        self.assertIn("frontend_node__2", body)
+        self.assertNotIn("backend_node 需要补 health version", body)
+
+    def test_should_skip_review_only_skips_same_event(self) -> None:
+        reviews = [
+            {"pull_request_number": 41, "event": "COMMENT"},
+            {"pull_request_number": 42, "event": "APPROVE"},
+        ]
+        self.assertTrue(should_skip_review(reviews=reviews, pr_number=41, event="COMMENT"))
+        self.assertFalse(should_skip_review(reviews=reviews, pr_number=41, event="REQUEST_CHANGES"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add lane-based parallel dispatch in crew construction
- normalize worker_lane in master_dispatch and route work items by lane
- persist lane-aware dispatch/runtime state and aggregate lane outputs

## Validation
- uv run python -m py_compile on updated modules
- instantiated MultiDev().crew() successfully
- smoke-tested worker_lane normalization and lane filtering
